### PR TITLE
[chore/project-setting] #1 Jacoco적용 및 테스트 환경에서 yml 파일 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### REST DOCS ###
 **/src/main/resources/static/docs/
+src/main/resources/application-secret.yml
+src/test/resources/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     kotlin("plugin.spring") version "1.6.21"
     kotlin("plugin.jpa") version "1.6.21"
     kotlin("plugin.allopen") version "1.4.32"
+    jacoco
 }
 
 group = "com.example"
@@ -63,6 +64,11 @@ dependencies {
 val snippetsDir by extra { file("build/generated-snippets")}
 tasks {
     test {
+        extensions.configure(JacocoTaskExtension::class) {
+            destinationFile = file("$buildDir/jacoco/jacoco.exec")
+        }
+        finalizedBy(jacocoTestReport)
+
         outputs.dir(snippetsDir)
     }
 
@@ -80,4 +86,65 @@ tasks {
     build {
         dependsOn(asciidoctor)
     }
+}
+
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.isEnabled = true
+        xml.isEnabled = false
+        csv.isEnabled = false
+    }
+
+    finalizedBy("jacocoTestCoverageVerification")
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.30".toBigDecimal()
+            }
+
+        }
+
+        rule {
+            enabled = true
+
+            element = "CLASS"
+
+            limit{
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.30".toBigDecimal()
+            }
+
+
+
+            limit {
+                counter = "LINE"
+                value = "TOTALCOUNT"
+                maximum = "200.0".toBigDecimal()
+            }
+
+            excludes = listOf(
+
+            )
+        }
+    }
+}
+
+val testCoverage by tasks.registering {
+    group = "verification"
+    description = "RUns the unit tests with coverage"
+
+    dependsOn(":test",
+    ":jacocoTestReport",
+    ":jacocoTestCoverageVerification")
+
+    tasks["jacocoTestReport"].mustRunAfter(tasks["test"])
+    tasks["jacocoTestCoverageVerification"].mustRunAfter(tasks["jacocoTestReport"])
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     // Database
     runtimeOnly("com.mysql:mysql-connector-j")
+
+    // Jasypt
+    implementation ("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4")
     // Springboot Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")

--- a/src/main/kotlin/com/example/jhouse_server/global/JasyptConfig.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/JasyptConfig.kt
@@ -1,0 +1,29 @@
+package com.example.jhouse_server.global
+
+import org.jasypt.encryption.StringEncryptor
+import org.jasypt.encryption.pbe.PooledPBEByteEncryptor
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JasyptConfig(
+        @Value("\${jasypt.encryptor.password}")
+        private val password: String
+){
+    @Bean("jasyptStringEncryptor")
+    fun stringEncryptor(): StringEncryptor {
+        val encryptor = PooledPBEStringEncryptor()
+        val config = SimpleStringPBEConfig()
+        config.password = password
+        config.algorithm = "PBEWITHMD5AndDES"
+        config.setKeyObtentionIterations("1000")
+        config.setPoolSize("1")
+        config.stringOutputType = "base64"
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator")
+        encryptor.setConfig(config)
+        return encryptor
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,12 +18,12 @@ spring:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
 
   datasource:
-    url: jdbc:mysql://localhost:3305/test_db?useSSL=false&serverTimezone=Asia/Seoul
-    username: test
-    password: test_pw
+    url: ENC(1r+PBQMs51lTSvcS47i8+ncEVMvbrng8XhrHtwmiE6JeQVm/Q07WLQ5HHOY5PCQFOBzWaZIoE4kxIKJJ0Wm366UrXRXmFued3NhOI7iE006ufGGEAGulRQ==)
+    username: ENC(Ft4VANPXNWbUqnXvim/g4w==)
+    password: ENC(35dJqCmjA0lYMfEv1EiKPw==)
     driver-class-name: com.mysql.cj.jdbc.Driver
   redis:
-    host: redis
+    host: ENC(Ua8NlOJqsCrv4+xRi1yNfg==)
     port: 6379
 
   mvc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name: jhouse-server
 
-#  profiles:
-#    include:
-#      secret
+  profiles:
+    include:
+      secret
 
   jpa:
     database: mysql

--- a/src/test/kotlin/com/example/jhouse_server/domain/UserRepositoryTests.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/UserRepositoryTests.kt
@@ -1,14 +1,16 @@
 package com.example.jhouse_server.domain
 
-import com.example.jhouse_server.domain.User
-import com.example.jhouse_server.domain.UserRepository
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit4.SpringRunner
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserRepositoryTests @Autowired constructor(


### PR DESCRIPTION
## Notice

1. Jacoco 라이브러리 도입에 따른 테스트 코드 커버리지 기준을 정해야 합니다.!
2. Repository 테스트를 위해 @ActiveProfiles("test") 어노테이션을 통해 application-test.yml 파일을 추가하였습니다. ( 이 파일은 메신저에서 확인해주시면 됩니다. )

test 환경에서 yml 파일을 따로 지정하지 않으면, main 환경의 기본 yml을 참조하도록 되어 있습니다. main 환경에서는 인텔리제이에서 제공하는 env 환경 세팅으로 jasypt password를 넘겨주고 있습니다. 
하지만 **test 환경에서는 이를 인식하지 못해 db url 을 참조하지 못한다는 오류**를 계속해서 발생시키고 있습니다. 따라서 위와 같이 yml 파일을 분리하였습니다.

혹시 좋은 아이디어 있으시면 의견 남겨주세요~!

## Reference
<img width="650" alt="image" src="https://user-images.githubusercontent.com/61505572/218973938-ccdaffad-bd93-48da-a855-7178769c18d6.png">

블로그를 통해 Jacoco를 도입하면서 확인한 적용 결과입니다.! 😊
