### PR TITLE
Feat/auth

### DIFF
--- a/src/main/kotlin/com/example/jhouse_server/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package com.example.jhouse_server.domain.user.controller
 
 import com.example.jhouse_server.domain.user.*
+import com.example.jhouse_server.domain.user.entity.Authority.USER
 import com.example.jhouse_server.domain.user.entity.User
 import com.example.jhouse_server.domain.user.service.UserService
 import com.example.jhouse_server.global.annotation.Auth
@@ -16,21 +17,21 @@ class UserController(
         val userService: UserService
 ) {
 
-    @GetMapping("/email-check/{email}")
+    @GetMapping("/check/email/{email}")
     fun emailCheck(
             @PathVariable("email") email: String
     ): ApplicationResponse<Boolean> {
         return ApplicationResponse.ok(userService.checkEmail(email))
     }
 
-    @GetMapping("/nick-name-check/{nick-name}")
+    @GetMapping("/check/nick-name/{nick-name}")
     fun nickNameCheck(
             @PathVariable("nick-name") nickName: String
     ): ApplicationResponse<Boolean> {
         return ApplicationResponse.ok(userService.checkNickName(nickName))
     }
 
-    @PostMapping("/send-sms")
+    @PostMapping("/send/sms")
     fun sendSms(
             @RequestParam("phone_num") phoneNum: String
     ): ApplicationResponse<Nothing> {
@@ -39,7 +40,7 @@ class UserController(
         return ApplicationResponse.ok()
     }
 
-    @PostMapping("/check-sms")
+    @PostMapping("/check/sms")
     fun checkSms(
             @RequestBody checkSmsReqDto: CheckSmsReqDto
     ): ApplicationResponse<Boolean> {
@@ -74,7 +75,29 @@ class UserController(
     fun logout(
             @AuthUser user: User
     ): ApplicationResponse<Nothing> {
-        userService.logout(user)
+        userService.logout(user.email)
+
+        return ApplicationResponse.ok()
+    }
+
+    @Auth
+    @PutMapping("/update/nick-name/{nick-name}")
+    fun updateNickName(
+            @AuthUser user: User,
+            @PathVariable("nick-name") nickName: String
+    ): ApplicationResponse<Nothing> {
+        userService.updateNickName(user, nickName)
+
+        return ApplicationResponse.ok()
+    }
+
+    @Auth
+    @PutMapping("/update/password/{password}")
+    fun updatePassword(
+            @AuthUser user: User,
+            @PathVariable("password") password: String
+    ): ApplicationResponse<Nothing> {
+        userService.updatePassword(user, password)
 
         return ApplicationResponse.ok()
     }

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
@@ -30,4 +30,12 @@ class User(
     fun update(phoneNum: String) {
         this.phoneNum = phoneNum
     }
+
+    fun updateNickName(nickName: String) {
+        this.nickName = nickName
+    }
+
+    fun updatePassword(password: String) {
+        this.password = password
+    }
 }

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/service/UserService.kt
@@ -24,5 +24,9 @@ interface UserService {
 
     fun reissue(tokenDto: TokenDto): TokenDto
 
-    fun logout(user: User)
+    fun logout(email: String)
+
+    fun updateNickName(user: User, nickName: String)
+
+    fun updatePassword(user: User, password: String)
 }

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/service/UserServiceImpl.kt
@@ -106,8 +106,27 @@ class UserServiceImpl (
         return updateTokenResponse
     }
 
-    override fun logout(user: User) {
-        redisUtil.deleteValues(user.email)
+    override fun logout(email: String) {
+        redisUtil.deleteValues(email)
+    }
+
+    @Transactional
+    override fun updateNickName(user: User, nickName: String) {
+        if (userRepository.existsByNickName(nickName)) {
+            throw ApplicationException(EXIST_NICK_NAME)
+        }
+
+        user.updateNickName(nickName)
+    }
+
+    @Transactional
+    override fun updatePassword(user: User, password: String) {
+        val encodePassword = encodePassword(password)
+        if (user.password == encodePassword) {
+            throw ApplicationException(SAME_PASSWORD)
+        }
+
+        user.updatePassword(encodePassword)
     }
 
     private fun createCode(): String {

--- a/src/main/kotlin/com/example/jhouse_server/global/HealthCheckController.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/HealthCheckController.kt
@@ -1,5 +1,8 @@
 package com.example.jhouse_server.global
 
+import com.example.jhouse_server.domain.user.entity.Authority
+import com.example.jhouse_server.domain.user.entity.Authority.ADMIN
+import com.example.jhouse_server.domain.user.entity.Authority.USER
 import com.example.jhouse_server.global.annotation.Auth
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -23,8 +26,14 @@ class HealthCheckController {
     }
 
     @Auth
-    @GetMapping("/api/auth/test")
+    @GetMapping("/api/auth/user")
     fun healthCheckV4() : String {
         return "못들어오지~?"
+    }
+
+    @Auth(ADMIN)
+    @GetMapping("/api/auth/admin")
+    fun healthCheckV5() : String {
+        return "관리자만 오시오"
     }
 }

--- a/src/main/kotlin/com/example/jhouse_server/global/annotation/Auth.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/annotation/Auth.kt
@@ -1,5 +1,9 @@
 package com.example.jhouse_server.global.annotation
 
+import com.example.jhouse_server.domain.user.entity.Authority
+
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Auth()
+annotation class Auth(
+        val auth: Authority = Authority.USER
+)

--- a/src/main/kotlin/com/example/jhouse_server/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/exception/ErrorCode.kt
@@ -20,6 +20,7 @@ enum class ErrorCode(
     NOT_SUPPORT_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J0003", "지원되지 않는 JWT 토큰입니다."),
     WRONG_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J0004", "JWT 토큰이 잘못되었습니다."),
     DONT_VALIDATE_TOKEN(HttpStatus.BAD_REQUEST, "J0005", "토큰 검증 실패"),
+    DONT_HAVE_AUTHORITY(HttpStatus.BAD_REQUEST, "J0006", "권한이 없습니다."),
 
     // User
     EXIST_PHONE_NUM(HttpStatus.BAD_REQUEST, "U0000", "이미 가입된 전화번호입니다."),
@@ -27,5 +28,6 @@ enum class ErrorCode(
     DONT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "U0002", "비밀번호가 일치하지 않습니다."),
     ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "U0003", "로그아웃 된 사용자입니다."),
     DONT_MATCH_WITH_TOKEN(HttpStatus.BAD_REQUEST, "U0004", "토큰의 유저 정보가 일치하지 않습니다."),
-
+    EXIST_NICK_NAME(HttpStatus.BAD_REQUEST, "U0005", "이미 존재하는 닉네임입니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "U0006", "비밀번호가 같습니다.")
 }

--- a/src/main/kotlin/com/example/jhouse_server/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/jwt/TokenProvider.kt
@@ -1,5 +1,6 @@
 package com.example.jhouse_server.global.jwt
 
+import com.example.jhouse_server.domain.user.entity.Authority
 import com.example.jhouse_server.domain.user.entity.User
 import com.example.jhouse_server.global.exception.ApplicationException
 import com.example.jhouse_server.global.exception.ErrorCode
@@ -81,5 +82,11 @@ class TokenProvider {
         val claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
 
         return claims.subject
+    }
+
+    fun getAuthority(token: String): Authority {
+        val claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
+
+        return Authority.valueOf(claims[AUTHORITIES_KEY].toString())
     }
 }


### PR DESCRIPTION
- 닉네임 & 비밀번호 수정 추가
- 추후 관리자 기능을 고려하여 Auth 어노테이션에 관리자 필터링 기능 추가
- 일반 사용자는 @Auth만을 api에 붙혀서 사용가능
- 관리자는 @Auth(Authority.ADMIN)을 붙혀서 사용가능
- @Auth(Authority.ADMIN) api에 USER권한을 가진 토큰으로 요청 시에 "권한 없음" 예외처리