### PR TITLE
[refactor/board-service] 게시글 임시저장여부 컬럼 삭제

### DIFF
--- a/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
@@ -16,8 +16,6 @@ data class BoardReqDto(
     @field:NotNull(message = "말머리는 필수값입니다.")
     val category: BoardCategory? = null,
     val imageUrls: List<String>,
-    @field:NotNull(message = "임시저장 여부는 필수값입니다.")
-    val saved: Boolean? = null,
     @field:NotNull(message = "게시글 타입은 필수값입니다.")
     val prefixCategory: PrefixCategory? = null,
     val fixed: Boolean? = null, // 홍보 게시글에 대해서만 true 설정 가능
@@ -42,8 +40,6 @@ data class BoardUpdateReqDto(
     @field:NotNull(message = "말머리는 필수값입니다.")
     val category: String? = null,
     val imageUrls: List<String>,
-    @field:NotNull(message = "임시저장 여부는 필수값입니다.")
-    val saved: Boolean? = null,
     @field:NotNull(message = "게시글 타입은 필수값입니다.")
     val prefixCategory: String? = null,
     val fixed: Boolean? = null,

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/Board.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/Board.kt
@@ -24,7 +24,6 @@ class Board(
     var category : BoardCategory,
     @Convert(converter = BoardImageUrlConverter::class) // 이미지 url ","로 슬라이싱
     var imageUrls : List<String>,
-    var saved: Boolean = true,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     var user : User,
@@ -49,7 +48,6 @@ class Board(
         content: String,
         category: String,
         imageUrls: List<String>,
-        saved: Boolean,
         prefixCategory: String
     ) : Board {
         this.title = title
@@ -58,7 +56,6 @@ class Board(
         this.category = BoardCategory.values().firstOrNull { it.name == category }
             ?: throw ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
         this.imageUrls = imageUrls
-        this.saved = saved
         this.prefixCategory = PrefixCategory.values().firstOrNull { it.name == prefixCategory }
             ?: throw ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
         return this

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardRepository.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface BoardRepository: JpaRepository<Board, Long>, BoardRepositoryCustom {
-    abstract fun findAllByPrefixCategoryAndSavedAndUseYn(prefixCategory : PrefixCategory, saved: Boolean, useYn: Boolean, pageable: Pageable): Page<Board>
+    abstract fun findAllByPrefixCategoryAndUseYn(prefixCategory : PrefixCategory, useYn: Boolean, pageable: Pageable): Page<Board>
     @Query(
         nativeQuery = true,
         value = "select * from board where prefix_category = :prefixCategory",

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
@@ -28,7 +28,7 @@ class BoardServiceImpl(
         val content = getContent(req.code!!)
         val fixed = if(req.prefixCategory == PrefixCategory.ADVERTISEMENT) req.fixed!! else false
         val board = Board(
-            req.title!!, req.code, content, req.category!!, req.imageUrls, req.saved!!, user, req.prefixCategory!!, fixed
+            req.title!!, req.code, content, req.category!!, req.imageUrls, user, req.prefixCategory!!, fixed
         )
         return boardRepository.save(board).id
     }
@@ -44,15 +44,13 @@ class BoardServiceImpl(
             content,
             req.category!!,
             req.imageUrls,
-            req.saved!!,
             req.prefixCategory!!
         ).id
     }
 
     override fun getBoardAll(category: String, pageable: Pageable): Page<BoardResDto> {
-        return boardRepository.findAllByPrefixCategoryAndSavedAndUseYn(
+        return boardRepository.findAllByPrefixCategoryAndUseYn(
             PrefixCategory.valueOf(category),
-            saved = true,
             useYn = true,
             pageable = pageable
         ).map{ toListDto(it) }

--- a/src/main/resources/static/docs/board.html
+++ b/src/main/resources/static/docs/board.html
@@ -451,9 +451,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2Nzk2Mzk2MTgsImF1dGgiOiJVU0VSIn0.hE5rHwPCisfSFZ1mAum7tJQVS2v1Yc9rU__RSRCa5g3mMhzdTic3pzd9yk0Uf1fGacJp95Jhp_WmLDx70GMV3Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODEwOTE5OTYsImF1dGgiOiJVU0VSIn0.TiS0d67QNdf0MMW_M5OiGARrJ-Co44Rxh-iYsF9g4YT1SG7SfcyrE6SsJNmi0MnjaWUyXJsr_R4X3CyrXdBKyQ
 Accept: application/json
-Content-Length: 334
+Content-Length: 316
 Host: localhost:8080
 
 {
@@ -461,7 +461,6 @@ Host: localhost:8080
   "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;감자머리 짱구는 내 친구. &lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;br/&gt; &lt;b&gt;안녕&lt;/b&gt; 하세요. 훈이에요.&lt;/div&gt; &lt;/body&gt;",
   "category" : "INTERIOR",
   "imageUrls" : [ "img006, img007" ],
-  "saved" : true,
   "prefixCategory" : "ADVERTISEMENT",
   "fixed" : true
 }</code></pre>
@@ -478,12 +477,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 64
+Content-Length: 63
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 106
+  "data" : 10
 }</code></pre>
 </div>
 </div>
@@ -496,9 +495,9 @@ Content-Length: 64
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2Nzk2Mzk2MTgsImF1dGgiOiJVU0VSIn0.hE5rHwPCisfSFZ1mAum7tJQVS2v1Yc9rU__RSRCa5g3mMhzdTic3pzd9yk0Uf1fGacJp95Jhp_WmLDx70GMV3Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODEwOTE5OTYsImF1dGgiOiJVU0VSIn0.TiS0d67QNdf0MMW_M5OiGARrJ-Co44Rxh-iYsF9g4YT1SG7SfcyrE6SsJNmi0MnjaWUyXJsr_R4X3CyrXdBKyQ
 Accept: application/json
-Content-Length: 330
+Content-Length: 312
 Host: localhost:8080
 
 {
@@ -506,7 +505,6 @@ Host: localhost:8080
   "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;주먹밥 머리 훈이는 내 친구. &lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;br/&gt; &lt;b&gt;안녕&lt;/b&gt; 하세요. 짱구에요.&lt;/div&gt; &lt;/body&gt;",
   "category" : "DAILY",
   "imageUrls" : [ "img004, img005" ],
-  "saved" : true,
   "prefixCategory" : "DEFAULT",
   "fixed" : false
 }</code></pre>
@@ -522,12 +520,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 64
+Content-Length: 62
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 104
+  "data" : 8
 }</code></pre>
 </div>
 </div>
@@ -541,9 +539,9 @@ Content-Length: 64
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2Nzk2Mzk2MTUsImF1dGgiOiJVU0VSIn0.XZ12xoDazab6koMpMZf5qZq-9UMn5T7Poa1gqu9VqkycKZ8l_2o2KLANXUwHPRQaJUuggZPjEJxx0iN6AEUfyQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODEwOTE5OTYsImF1dGgiOiJVU0VSIn0.TiS0d67QNdf0MMW_M5OiGARrJ-Co44Rxh-iYsF9g4YT1SG7SfcyrE6SsJNmi0MnjaWUyXJsr_R4X3CyrXdBKyQ
 Accept: application/json
-Content-Length: 335
+Content-Length: 317
 Host: localhost:8080
 
 {
@@ -551,7 +549,6 @@ Host: localhost:8080
   "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;오도이촌 소개를 해보겠습니다. &lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;br/&gt; &lt;b&gt;안녕&lt;/b&gt; 하세요. 오도리입니다.&lt;/div&gt; &lt;/body&gt;",
   "category" : "REVIEW",
   "imageUrls" : [ "img002, img003" ],
-  "saved" : true,
   "prefixCategory" : "INTRO",
   "fixed" : false
 }</code></pre>
@@ -567,12 +564,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 63
+Content-Length: 62
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 99
+  "data" : 3
 }</code></pre>
 </div>
 </div>
@@ -599,46 +596,46 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 976
+Content-Length: 974
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "boardId" : 100,
+      "boardId" : 4,
       "title" : "짱구는 못말려",
       "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-03-24",
+      "createdAt" : "2023-04-10",
       "imageUrl" : "img001",
-      "commentCount" : 0
+      "commentCount" : 1
     } ],
     "pageable" : {
       "sort" : {
-        "sorted" : false,
+        "empty" : true,
         "unsorted" : true,
-        "empty" : true
+        "sorted" : false
       },
-      "pageNumber" : 0,
-      "pageSize" : 20,
       "offset" : 0,
-      "unpaged" : false,
-      "paged" : true
+      "pageSize" : 20,
+      "pageNumber" : 0,
+      "paged" : true,
+      "unpaged" : false
     },
-    "totalPages" : 1,
-    "totalElements" : 1,
     "last" : true,
-    "numberOfElements" : 1,
-    "sort" : {
-      "sorted" : false,
-      "unsorted" : true,
-      "empty" : true
-    },
-    "number" : 0,
-    "first" : true,
+    "totalElements" : 1,
+    "totalPages" : 1,
     "size" : 20,
+    "sort" : {
+      "empty" : true,
+      "unsorted" : true,
+      "sorted" : false
+    },
+    "first" : true,
+    "number" : 0,
+    "numberOfElements" : 1,
     "empty" : false
   }
 }</code></pre>
@@ -652,7 +649,7 @@ Content-Length: 976
 <h5 id="_request_5">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/101 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/5 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -667,21 +664,26 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 408
+Content-Length: 551
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "boardId" : 101,
+    "boardId" : 5,
     "title" : "짱구는 못말려",
     "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
     "nickName" : "테스트유저1",
-    "createdAt" : "2023-03-24",
+    "createdAt" : "2023-04-10",
     "imageUrls" : [ "img001" ],
     "loveCount" : 0,
-    "commentCount" : 0,
-    "comments" : [ ]
+    "commentCount" : 1,
+    "comments" : [ {
+      "commentId" : 12159,
+      "nickName" : "테스트유저1",
+      "content" : "댓글이란다.",
+      "createdAt" : "2023-04-10"
+    } ]
   }
 }</code></pre>
 </div>
@@ -694,11 +696,11 @@ Content-Length: 408
 <h5 id="_request_6">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/boards/102 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/boards/6 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2Nzk2Mzk2MTgsImF1dGgiOiJVU0VSIn0.hE5rHwPCisfSFZ1mAum7tJQVS2v1Yc9rU__RSRCa5g3mMhzdTic3pzd9yk0Uf1fGacJp95Jhp_WmLDx70GMV3Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODEwOTE5OTYsImF1dGgiOiJVU0VSIn0.TiS0d67QNdf0MMW_M5OiGARrJ-Co44Rxh-iYsF9g4YT1SG7SfcyrE6SsJNmi0MnjaWUyXJsr_R4X3CyrXdBKyQ
 Accept: application/json
-Content-Length: 273
+Content-Length: 255
 Host: localhost:8080
 
 {
@@ -706,7 +708,6 @@ Host: localhost:8080
   "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
   "category" : "TREND",
   "imageUrls" : [ "img001" ],
-  "saved" : true,
   "prefixCategory" : "INTRO",
   "fixed" : false
 }</code></pre>
@@ -722,12 +723,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 64
+Content-Length: 62
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 102
+  "data" : 6
 }</code></pre>
 </div>
 </div>
@@ -739,8 +740,8 @@ Content-Length: 64
 <h5 id="_request_7">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/boards/97 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2Nzk2Mzk2MTUsImF1dGgiOiJVU0VSIn0.XZ12xoDazab6koMpMZf5qZq-9UMn5T7Poa1gqu9VqkycKZ8l_2o2KLANXUwHPRQaJUuggZPjEJxx0iN6AEUfyQ
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/boards/1 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODEwOTE5OTUsImF1dGgiOiJVU0VSIn0.yQMO0sg71gwRTZqkQ3_9DrMAB6xDnO3zdTtAOqi-SxcSbP1oS99XNHMa0VpHKnQSBH3k_eeDnqT5HPUqnCSkfw
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -808,7 +809,7 @@ Content-Length: 168
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-03-23 17:58:55 +0900
+Last updated 2023-04-04 02:29:34 +0900
 </div>
 </div>
 </body>

--- a/src/test/kotlin/com/example/jhouse_server/domain/board/controller/BoardControllerTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/board/controller/BoardControllerTest.kt
@@ -189,7 +189,6 @@ internal class BoardControllerTest @Autowired constructor(
             fieldWithPath("code").description("DB에 저장할 html 정적 코드"),
             fieldWithPath("category").description("게시글 말머리"),
             fieldWithPath("imageUrls").description("이미지 url ',' 구분자로 넘겨주기 "),
-            fieldWithPath("saved").description("임시저장여부, 임시저장 false, 저장 true"),
             fieldWithPath("prefixCategory").description("게시글 타입, [DEFAULT, INTRO, ADVERTISEMENT]"),
             fieldWithPath("fixed").description("고정여부, 고정x false, 고정 true"),
         )

--- a/src/test/kotlin/com/example/jhouse_server/global/util/MockEntity.kt
+++ b/src/test/kotlin/com/example/jhouse_server/global/util/MockEntity.kt
@@ -91,7 +91,6 @@ class MockEntity {
             code = "<body> <div> <h2>짱구는 못말려</h2> </div> <div> <i>철수</i>야 나랑 놀자 </div> </body>",
             category = BoardCategory.TREND,
             imageUrls = mutableListOf("img001"),
-            saved = true,
             prefixCategory = PrefixCategory.INTRO,
             fixed = false
         )
@@ -100,7 +99,6 @@ class MockEntity {
             code = "<body> <div> <h2>짱구는 못말려</h2> </div> <div> <i>철수</i>야 나랑 놀자 </div> </body>",
             category = "REVIEW",
             imageUrls = mutableListOf("img001"),
-            saved = true,
             prefixCategory = "INTRO",
             fixed = false
         )
@@ -120,7 +118,6 @@ class MockEntity {
             code = "<body> <div> <h2>오도이촌 소개를 해보겠습니다. </h2> </div> <div> <br/> <b>안녕</b> 하세요. 오도리입니다.</div> </body>",
             category = BoardCategory.REVIEW,
             imageUrls = mutableListOf("img002, img003"),
-            saved = true,
             prefixCategory = PrefixCategory.INTRO,
             fixed = false
         )
@@ -129,7 +126,6 @@ class MockEntity {
             code = "<body> <div> <h2>주먹밥 머리 훈이는 내 친구. </h2> </div> <div> <br/> <b>안녕</b> 하세요. 짱구에요.</div> </body>",
             category = BoardCategory.DAILY,
             imageUrls = mutableListOf("img004, img005"),
-            saved = true,
             prefixCategory = PrefixCategory.DEFAULT,
             fixed = false
         )
@@ -138,7 +134,6 @@ class MockEntity {
             code = "<body> <div> <h2>감자머리 짱구는 내 친구. </h2> </div> <div> <br/> <b>안녕</b> 하세요. 훈이에요.</div> </body>",
             category = BoardCategory.INTERIOR,
             imageUrls = mutableListOf("img006, img007"),
-            saved = true,
             prefixCategory = PrefixCategory.ADVERTISEMENT,
             fixed = true
         )


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

임시저장여부 컬럼 삭제

## 작업 내용
- [x] 코틀린 코트에서 임시저장여부 변수 삭제
- [x] 운영 디비 drop 테이블 후, create

## 변경점

- 임시저장여부 컬럼 삭제

이유 : 기획 측에 확인 결과, 임시저장여부는 기능에서 제외되었습니다.

## CheckList

- [ ] CI를 통과했나요?
- [x] 리뷰어를 등록했나요?
- [ ] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?