### PR TITLE
[refactor/board-service] 게시글 테이블 분리 작업 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ sonarqube {
         property("sonar.test.inclusions", "**/*Test.kt")
         property("sonar.exclusions", "**/test/**, **/resources/**, **/docs/**, **/*Application*.kt, **/global/**, **/dto/**, **/*Exception*.kt, **/*ErrorCode*.kt, **/*Category*.kt, **/admin/**, **/*RepositoryImpl.kt" )
         property("sonar.java.coveragePlugin", "jacoco")
-        property("sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/html/jacocoTestReport.xml")
+        property("sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/customJacocoReportDir/test/jacocoTestReport.xml")
     }
 }
 

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
@@ -63,11 +63,11 @@ data class BoardResOneDto(
 
 fun toListDto(board : Board) : BoardResDto {
     val oneLineContent = if(board.content.length >= 50) board.content.substring(0 until 50) else board.content// 50자 슬라이싱
-    return BoardResDto(board.id, board.title, board.code, oneLineContent, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls[0], board.comment.size, board.category.name, board.prefixCategory.name)
+    return BoardResDto(board.id, board.title, board.boardCode.code, oneLineContent, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls[0], board.comment.size, board.category.name, board.prefixCategory.name)
 }
 
 fun toDto(board: Board) : BoardResOneDto {
-    return BoardResOneDto(board.id, board.title, board.code, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls, board.love.size, board.category.name, board.prefixCategory.name, board.comment.size, board.comment.stream().map { com.example.jhouse_server.domain.comment.dto.toDto(it) }.toList())
+    return BoardResOneDto(board.id, board.title, board.boardCode.code, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls, board.love.size, board.category.name, board.prefixCategory.name, board.comment.size, board.comment.stream().map { com.example.jhouse_server.domain.comment.dto.toDto(it) }.toList())
 }
 
 data class CodeResDto(

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/Board.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/Board.kt
@@ -18,10 +18,11 @@ import javax.persistence.*
 )
 class Board(
     var title: String,
-    var code: String,
+    @Column(length = Int.MAX_VALUE)
     var content : String,
     @Convert(converter = BoardCategoryConverter::class)
     var category : BoardCategory,
+    @Column(length = Int.MAX_VALUE)
     @Convert(converter = BoardImageUrlConverter::class) // 이미지 url ","로 슬라이싱
     var imageUrls : List<String>,
     @ManyToOne(fetch = FetchType.LAZY)
@@ -30,9 +31,11 @@ class Board(
     @Convert(converter = PrefixCategoryConverter::class)
     var prefixCategory : PrefixCategory,
     var fixed : Boolean = false,
+    @OneToOne @JoinColumn(name = "id")
+    var boardCode: BoardCode,
     @LastModifiedDate
     @Column(updatable = true)
-    var fixedAt : LocalDateTime? = null,
+    var fixedAt : LocalDateTime = LocalDateTime.now(),
     var useYn : Boolean = true,
     @OneToMany(mappedBy = "board", cascade = [CascadeType.ALL], orphanRemoval = true)
     var love : MutableList<Love> = mutableListOf(),
@@ -44,14 +47,14 @@ class Board(
 
     fun updateEntity(
         title: String,
-        code: String,
+        code: BoardCode,
         content: String,
         category: String,
         imageUrls: List<String>,
         prefixCategory: String
     ) : Board {
         this.title = title
-        this.code = code
+        this.boardCode = code
         this.content = content
         this.category = BoardCategory.values().firstOrNull { it.name == category }
             ?: throw ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/BoardCode.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/BoardCode.kt
@@ -1,0 +1,23 @@
+package com.example.jhouse_server.domain.board.entity
+
+import com.example.jhouse_server.global.entity.BaseEntity
+import javax.persistence.*
+
+@Entity
+@Table(
+    name = "board_code"
+)
+class BoardCode(
+    @Column(length = Int.MAX_VALUE)
+    var code: String,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id : Long = 0L
+) : BaseEntity() {
+
+    fun updateEntity(
+        code: String
+    ) : BoardCode {
+        this.code = code
+        return this
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardCodeRepository.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardCodeRepository.kt
@@ -1,0 +1,8 @@
+package com.example.jhouse_server.domain.board.repository
+
+import com.example.jhouse_server.domain.board.entity.BoardCode
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BoardCodeRepository : JpaRepository<BoardCode, Long> {
+
+}

--- a/src/test/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImplTest.kt
@@ -210,7 +210,7 @@ internal class BoardServiceImplTest @Autowired constructor(
         // when
         val res = boardService.getBoardAll(category, pageable)
         // then
-        assertThat(res.content[0].oneLineContent.length).isLessThan(50)
+        assertThat(res.content[0].oneLineContent.length).isLessThan(51)
     }
     @Test
     @DisplayName("게시글 조회_삭제된 게시글 미노출")


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

Board와 BoardCode 로 테이블 분리

## 작업 내용
- [x] Board와 BoardCode 로 테이블 분리

## 변경점

- Board와 BoardCode 로 테이블 분리

이유 : 게시글 테이블 내에 많은 컬럼이 존재하고, code 컬럼과 content 컬럼, image_url 컬럼이 최대로 가질 수 있는 길이로 지정되었을 때 하나의 row가 가질 수 있는 길이를 벗어난 데이터를 입력할 수 없기 때문에 테이블 분리를 결정하였습니다.

## CheckList

- [ ] CI를 통과했나요?
- [ ] 리뷰어를 등록했나요?
- [ ] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?