### PR TITLE
[refactor/board-service] 게시글 조회 시, 응답 데이터 컨버팅 로직 수정

### DIFF
--- a/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
@@ -4,7 +4,9 @@ import com.example.jhouse_server.domain.board.entity.Board
 import com.example.jhouse_server.domain.board.entity.BoardCategory
 import com.example.jhouse_server.domain.comment.dto.CommentResDto
 import java.sql.Timestamp
-import java.util.Date
+import java.util.*
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 import javax.validation.constraints.NotNull
 import kotlin.streams.toList
 
@@ -62,12 +64,17 @@ data class BoardResOneDto(
 )
 
 fun toListDto(board : Board) : BoardResDto {
-    val oneLineContent = if(board.content.length >= 50) board.content.substring(0 until 50) else board.content// 50자 슬라이싱
+    val oneLineContent = sliceContentWithRegex(board.content)
     return BoardResDto(board.id, board.title, board.boardCode.code, oneLineContent, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls[0], board.comment.size, board.category.name, board.prefixCategory.name)
 }
 
 fun toDto(board: Board) : BoardResOneDto {
     return BoardResOneDto(board.id, board.title, board.boardCode.code, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls, board.love.size, board.category.name, board.prefixCategory.name, board.comment.size, board.comment.stream().map { com.example.jhouse_server.domain.comment.dto.toDto(it) }.toList())
+}
+fun sliceContentWithRegex(content : String) : String {
+    val pattern = Regex("^[a-zA-Z가-힣].*[.!?]$")
+    val validatedString = pattern.find(content)?.value ?: ""
+    return validatedString.take(200)
 }
 
 data class CodeResDto(

--- a/src/test/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImplTest.kt
@@ -210,7 +210,7 @@ internal class BoardServiceImplTest @Autowired constructor(
         // when
         val res = boardService.getBoardAll(category, pageable)
         // then
-        assertThat(res.content[0].oneLineContent.length).isLessThan(51)
+        assertThat(res.content[0].oneLineContent.length).isLessThan(201)
     }
     @Test
     @DisplayName("게시글 조회_삭제된 게시글 미노출")


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

응답 데이터로 컨버팅 시, 정규표현식을 통해 문장에 대한 검증과 200자 이내 슬라이싱 처리

## 작업 내용
- [x] 응답 데이터로 컨버팅 시, 정규표현식을 통해 문장에 대한 검증과 200자 이내 슬라이싱 처리

## 변경점

- 응답 데이터로 컨버팅 시, 정규표현식을 통해 문장에 대한 검증과 200자 이내 슬라이싱 처리

이유 : 미리보기 문구의 내용을 기존 ( 50자 ) 에서 ( 200자 )로 변경 및 하나의 문장을 이루는 문자열 반환을 기획팀에서 요청하였기 때문입니다.

## CheckList

- [x] CI를 통과했나요?
- [x] 리뷰어를 등록했나요?
- [x] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?