### PR TITLE
[Feat/house-service] 빈집 거래 API 구현

### DIFF
--- a/src/docs/asciidoc/house.adoc
+++ b/src/docs/asciidoc/house.adoc
@@ -1,0 +1,48 @@
+== House API
+
+==== 1. 빈집 게시글 작성하기
+===== Request
+include::{snippets}/save-house/http-request.adoc[]
+====== Request fields
+include::{snippets}/save-house/request-fields.adoc[]
+===== Response
+include::{snippets}/save-house/http-response.adoc[]
+===== Response fields
+include::{snippets}/save-house/response-fields.adoc[]
+
+==== 2. 빈집 게시글 수정하기
+===== Request
+include::{snippets}/update-house/http-request.adoc[]
+===== Request Fields
+include::{snippets}/update-house/request-fields.adoc[]
+
+===== Response
+include::{snippets}/update-house/http-response.adoc[]
+
+==== 3. 빈집 게시글 삭제하기
+삭제 시, 빈집 게시글 아이디를 path-variable로 넘겨주세요.
+
+===== Request
+include::{snippets}/delete-house/http-request.adoc[]
+===== Response
+include::{snippets}/delete-house/http-response.adoc[]
+
+
+==== 4. 빈집 게시글 목록 조회
+===== Request
+include::{snippets}/get-house-all/http-request.adoc[]
+====== Request Fields
+include::{snippets}/get-house-all/request-parameters.adoc[]
+
+====== Response
+include::{snippets}/get-house-all/http-response.adoc[]
+====== Response Fields
+include::{snippets}/get-house-all/response-fields-data.adoc[]
+
+===== 5. 빈집 게시글 단일 조회
+====== Request
+include::{snippets}/get-house-one/http-request.adoc[]
+====== Response
+include::{snippets}/get-house-one/http-response.adoc[]
+====== Response Fields
+include::{snippets}/get-house-one/response-fields.adoc[]

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
@@ -88,42 +88,40 @@ class BoardServiceImpl(
     override fun getCategory(name: String): List<CodeResDto> {
         return BoardCategory.values().filter { it.superCategory.name == name }.map { CodeResDto(it.value, it.name) }
     }
+경}
+fun getContent(code: String): String {
+    var str = code
+    str = Normalizer.normalize(str, Normalizer.Form.NFKC)
+    var mat: Matcher
 
+    // <script> 파싱
+    val script = Pattern.compile("<(no)?script[^>]*>.*?</(no)?script>", Pattern.DOTALL)
+    mat = script.matcher(str)
+    str = mat.replaceAll("")
 
-    fun getContent(code: String): String {
-        var str = code
-        str = Normalizer.normalize(str, Normalizer.Form.NFKC)
-        var mat: Matcher
+    // <style> 파싱
+    val style = Pattern.compile("<style[^>]*>.*</style>", Pattern.DOTALL)
+    mat = style.matcher(str)
+    str = mat.replaceAll("")
 
-        // <script> 파싱
-        val script = Pattern.compile("<(no)?script[^>]*>.*?</(no)?script>", Pattern.DOTALL)
-        mat = script.matcher(str)
-        str = mat.replaceAll("")
+    // <tag> 파싱
+    val tag = Pattern.compile("<(\"[^\"]*\"|\'[^\']*\'|[^\'\">])*>")
+    mat = tag.matcher(str)
+    str = mat.replaceAll("")
 
-        // <style> 파싱
-        val style = Pattern.compile("<style[^>]*>.*</style>", Pattern.DOTALL)
-        mat = style.matcher(str)
-        str = mat.replaceAll("")
+    // ntag 파싱
+    val ntag = Pattern.compile("<\\w+\\s+[^<]*\\s*>")
+    mat = ntag.matcher(str)
+    str = mat.replaceAll("")
 
-        // <tag> 파싱
-        val tag = Pattern.compile("<(\"[^\"]*\"|\'[^\']*\'|[^\'\">])*>")
-        mat = tag.matcher(str)
-        str = mat.replaceAll("")
+    // entity ref 처리
+    val entity = Pattern.compile("&[^;]+;")
+    mat = entity.matcher(str)
+    str = mat.replaceAll("")
 
-        // ntag 파싱
-        val ntag = Pattern.compile("<\\w+\\s+[^<]*\\s*>")
-        mat = ntag.matcher(str)
-        str = mat.replaceAll("")
-
-        // entity ref 처리
-        val entity = Pattern.compile("&[^;]+;")
-        mat = entity.matcher(str)
-        str = mat.replaceAll("")
-
-        // whitespace 처리
-        val wspace = Pattern.compile("\\s\\s+")
-        mat = wspace.matcher(str)
-        str = mat.replaceAll("")
-        return str
-    }
+    // whitespace 처리
+    val wspace = Pattern.compile("\\s\\s+")
+    mat = wspace.matcher(str)
+    str = mat.replaceAll("")
+    return str
 }

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
@@ -88,7 +88,7 @@ class BoardServiceImpl(
     override fun getCategory(name: String): List<CodeResDto> {
         return BoardCategory.values().filter { it.superCategory.name == name }.map { CodeResDto(it.value, it.name) }
     }
-경}
+}
 fun getContent(code: String): String {
     var str = code
     str = Normalizer.normalize(str, Normalizer.Form.NFKC)

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/controller/HouseController.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/controller/HouseController.kt
@@ -1,0 +1,111 @@
+package com.example.jhouse_server.domain.house.controller
+
+import com.example.jhouse_server.domain.board.BoardListDto
+import com.example.jhouse_server.domain.house.dto.HouseListDto
+import com.example.jhouse_server.domain.house.dto.HouseReqDto
+import com.example.jhouse_server.domain.house.dto.HouseResDto
+import com.example.jhouse_server.domain.house.dto.HouseResOneDto
+import com.example.jhouse_server.domain.house.service.HouseService
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.global.annotation.Auth
+import com.example.jhouse_server.global.annotation.AuthUser
+import com.example.jhouse_server.global.aop.EnableValidation
+import com.example.jhouse_server.global.response.ApplicationResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@EnableValidation
+@RestController
+@RequestMapping("/api/v1/houses")
+class HouseController(
+    val houseService: HouseService
+) {
+
+    /**
+     * 빈집 게시글 작성
+     *
+     * @author dldmsql
+     * @param req HouseReqDto 빈집 게시글 작성 시, 입력되는 데이터
+     * @param user User RefreshToken 기반 인증/인가 처리된 사용자 데이터
+     * @return house_id 빈집 게시글 ID
+     * @exception INVALID_VALUE_EXCEPTION C0002 올바르지 않은 요청입니다. ( 유효성 검사 실패 시 )
+     * */
+    @Auth
+    @PostMapping
+    fun createHouse(
+        @RequestBody @Validated req: HouseReqDto,
+        @AuthUser user: User
+    ) : ApplicationResponse<Long> {
+        return ApplicationResponse.ok(houseService.createHouse(req, user))
+    }
+
+    /**
+     * 빈집 게시글 수정
+     *
+     * @author dldmsql
+     * @param houseId Long 빈집 게시글 ID
+     * @param req HouseReqDto 빈집 게시글 작성 시, 입력되는 데이터
+     * @param user User RefreshToken 기반 인증/인가 처리된 사용자 데이터
+     * @return house_id 빈집 게시글 ID
+     * @exception INVALID_VALUE_EXCEPTION C0002 올바르지 않은 요청입니다. ( 유효성 검사 실패 시 )
+     * */
+    @Auth
+    @PutMapping("/{houseId}")
+    fun updateHouse(
+        @PathVariable houseId: Long,
+        @RequestBody @Validated req: HouseReqDto,
+        @AuthUser user: User
+    ) : ApplicationResponse<Long> {
+        return ApplicationResponse.ok(houseService.updateHouse(houseId, req, user))
+    }
+
+    /**
+     * 빈집 게시글 삭제
+     *
+     * @author dldmsql
+     * @param houseId Long 빈집 게시글 ID
+     * @param user User
+     * */
+    @Auth
+    @DeleteMapping("/{houseId}")
+    fun deleteHouse(
+        @PathVariable houseId: Long,
+        @AuthUser user: User
+    ) : ApplicationResponse<Nothing> {
+        houseService.deleteHouse(houseId, user)
+        return ApplicationResponse.ok()
+    }
+
+    /**
+     * 빈집 게시글 리스트 조회
+     *
+     * @author dldmsql
+     * @param houseListDto HouseListDto 게시글 조회를 위한 기본 검색 조건 ( 매물 타입, 도시, 검색어 )
+     * @param pageable Pageable 페이징처리를 위한 인터페이스
+     * @return Page<HouseResDto>
+     * */
+    @GetMapping
+    fun getHouseAll(
+        @ModelAttribute houseListDto: HouseListDto,
+        @PageableDefault(size=8, page=0) pageable: Pageable
+    ) : ApplicationResponse<Page<HouseResDto>> {
+        return ApplicationResponse.ok(houseService.getHouseAll(houseListDto, pageable))
+    }
+
+    /**
+     * 빈집 게시글 상세 조회
+     *
+     * @author dldmsql
+     * @param houseId Long 빈집 게시글 ID
+     * @return HouseResOneDto
+     * */
+    @GetMapping("/{houseId}")
+    fun getHouseOne(
+        @PathVariable houseId: Long
+    ) : ApplicationResponse<HouseResOneDto> {
+        return ApplicationResponse.ok(houseService.getHouseOne(houseId))
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/dto/HouseReqDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/dto/HouseReqDto.kt
@@ -1,0 +1,80 @@
+package com.example.jhouse_server.domain.house.dto
+
+import com.example.jhouse_server.domain.house.entity.House
+import com.example.jhouse_server.domain.house.entity.RentalType
+import java.sql.Timestamp
+import java.util.*
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+data class HouseReqDto(
+    @field:NotNull(message = "매매 타입은 필수값입니다.")
+    val rentalType: RentalType? = null,
+    @field:NotNull(message = "주소는 필수값입니다. ( 예: 서울/인천 ~ )")
+    val city: String?,
+    @field:NotNull(message = "우편번호는 필수값입니다.")
+    val zipCode: String?,
+    @field:NotNull(message = "집 크기는 필수값입니다. ( m^2 단위로 산정해서 작성할 것 )")
+    val size: String?,
+    @field:NotNull(message = "매물 목적/용도는 필수값입니다.")
+    val purpose: String?,
+    var floorNum: Int,
+    var sumFloor: Int,
+    @field:NotNull(message = "연락처는 필수값입니다.")
+    var contact: String?,
+    var createdDate: String,
+    @field:NotNull(message = "매물 가격은 필수값입니다.")
+    var price: Int?,
+    var monthlyPrice: Double,
+    val agentName : String,
+    val title: String,
+    val code: String,
+    val imageUrls: List<String>
+)
+data class HouseListDto(
+    val rentalType: String,
+    val city: String?,
+    val search: String?
+)
+data class HouseResDto(
+    val houseId: Long,
+    val rentalType: RentalType,
+    val city: String,
+    val price: Int,
+    val monthlyPrice: Double,
+    val nickName: String,
+    val createdAt: Date,
+    val isCompleted: Boolean
+)
+data class HouseResOneDto(
+    val houseId: Long,
+    val rentalType: RentalType,
+    val city: String,
+    val zipcode: String,
+    val purpose: String,
+    val floorNum: Int,
+    val sumFloor: Int,
+    val contact: String,
+    val createdDate: String, // 준공연도
+    val price: Int,
+    val monthlyPrice: Double,
+    val agentName: String, // 공인중개사명
+    val title: String,
+    val code: String,
+    val imageUrls: List<String>,
+    val nickName: String, // 게시글 작성자
+    val createdAt: Date,
+    val isCompleted: Boolean
+)
+
+fun toDto(house: House) : HouseResOneDto {
+    return HouseResOneDto(house.id, house.houseType, house.address.city,
+        house.address.zipcode, house.purpose, house.floorNum, house.sumFloor, house.contact,
+        house.createdDate, house.price, house.monthlyPrice,
+        house.agentName, house.title, house.code, house.imageUrls, house.user.nickName,
+        Timestamp.valueOf(house.createdAt), false)
+}
+
+fun toListDto(house: House) : HouseResDto {
+    return HouseResDto(house.id, house.houseType!!, house.address.city, house.price, house.monthlyPrice, house.user.nickName, Timestamp.valueOf(house.createdAt), false )
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/entity/Address.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/entity/Address.kt
@@ -1,0 +1,19 @@
+package com.example.jhouse_server.domain.house.entity
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class Address(
+        @Column
+        var city: String, // 시도
+
+        @Column
+        var zipcode: String, // 우편번호
+) {
+    fun updateEntity(city: String, zipCode: String) : Address {
+        this.city = city
+        this.zipcode = zipCode
+        return this
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/entity/Deal.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/entity/Deal.kt
@@ -1,0 +1,22 @@
+package com.example.jhouse_server.domain.house.entity
+
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.global.entity.BaseEntity
+import javax.persistence.*
+
+@Entity
+class Deal(
+
+    @Convert(converter = DealStateConverter::class)
+    var dealState : DealState,
+
+    @OneToOne
+    var buyer: User,
+
+    @OneToOne
+    var house: House,
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id : Long = 0L
+) : BaseEntity() {
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/entity/DealStateConverter.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/entity/DealStateConverter.kt
@@ -1,0 +1,20 @@
+package com.example.jhouse_server.domain.house.entity
+
+import javax.persistence.AttributeConverter
+import javax.persistence.Converter
+
+@Converter(autoApply = true)
+class DealStateConverter : AttributeConverter<DealState, String> {
+    override fun convertToDatabaseColumn(attribute: DealState?): String? {
+        return attribute?.name
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): DealState? {
+        return DealState.values().firstOrNull {it.name == dbData}
+    }
+}
+
+enum class DealState {
+    ONGOING,
+    COMPLETED,
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/entity/House.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/entity/House.kt
@@ -1,0 +1,95 @@
+package com.example.jhouse_server.domain.house.entity
+
+import com.example.jhouse_server.domain.board.PrefixCategory
+import com.example.jhouse_server.domain.board.entity.*
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.global.entity.BaseEntity
+import com.example.jhouse_server.global.exception.ApplicationException
+import com.example.jhouse_server.global.exception.ErrorCode
+import java.time.LocalDate
+import javax.persistence.*
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+@Entity
+class House(
+    @Convert(converter = RentalTypeConverter::class)
+    var houseType: RentalType, // 매물유형
+
+    @Embedded
+    var address: Address, // 주소
+
+    var size: String, // 집 크기( m2 )
+
+    var purpose: String, // 용도 ( 예: 주택 )
+
+    @Column(nullable = true)
+    var floorNum : Int, // 층수 ( 다가구인 경우에만 )
+
+    @Column(nullable = true)
+    var sumFloor : Int, // 총 층수
+
+    var contact : String, // 바로 연락 가능한 연락처
+
+    var createdDate : String, // 준공연도,
+
+    var price: Int, // 매물가격
+
+    @Column(nullable = true)
+    var monthlyPrice : Double, // 월세의 경우,
+
+    var agentName: String, // 공인중개사명
+    var title: String, // 게시글 제목
+    @Column(length = Int.MAX_VALUE)
+    var content : String, // 게시글 내용
+    @Column(length = Int.MAX_VALUE)
+    var code : String, // 게시글 코드
+    @Column(length = Int.MAX_VALUE)
+    @Convert(converter = BoardImageUrlConverter::class) // 이미지 url ","로 슬라이싱
+    var imageUrls : List<String>,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user : User,
+    var useYn : Boolean = true, // 삭제여부
+    @OneToMany(mappedBy = "house", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var scrap: MutableList<Scrap> = mutableListOf(),
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseEntity() {
+
+    fun updateEntity(
+         rentalType: RentalType,
+         size: String,
+         purpose: String,
+         floorNum: Int,
+         sumFloor: Int,
+         contact: String,
+         createdDate: String,
+         price: Int,
+         monthlyPrice: Double,
+         agentName : String,
+         title: String,
+         code: String,
+         content : String,
+         imageUrls: List<String>
+    ) : House {
+        this.houseType = rentalType
+        this.size = size
+        this.purpose = purpose
+        this.floorNum = floorNum
+        this.sumFloor = sumFloor
+        this.contact = contact
+        this.createdDate = createdDate
+        this.price = price
+        this.monthlyPrice = monthlyPrice
+        this.agentName = agentName
+        this.title = title
+        this.code = code
+        this.content = content
+        this.imageUrls = imageUrls
+        return this
+    }
+    fun deleteEntity() {
+        this.useYn = false
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/entity/HouseTypeConverter.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/entity/HouseTypeConverter.kt
@@ -1,0 +1,23 @@
+package com.example.jhouse_server.domain.house.entity
+
+import javax.persistence.AttributeConverter
+import javax.persistence.Converter
+
+@Converter(autoApply = true)
+class RentalTypeConverter : AttributeConverter<RentalType, String> {
+    override fun convertToDatabaseColumn(attribute: RentalType?): String? {
+        return attribute?.name
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): RentalType? {
+        return RentalType.values().firstOrNull {it.name == dbData}
+    }
+
+}
+
+enum class RentalType(val value: String) {
+    SALE("매매"),
+    JEONSE("전세"),
+    MONTHLYRENT("월세"),
+    ;
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/entity/Scrap.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/entity/Scrap.kt
@@ -1,0 +1,21 @@
+package com.example.jhouse_server.domain.house.entity
+
+import com.example.jhouse_server.domain.house.entity.House
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.global.entity.BaseEntity
+import javax.persistence.*
+
+@Entity
+class Scrap(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var subscriber: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "house_id")
+    var house : House,
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+) : BaseEntity() {
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/repository/HouseRepository.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/repository/HouseRepository.kt
@@ -1,0 +1,7 @@
+package com.example.jhouse_server.domain.house.repository
+
+import com.example.jhouse_server.domain.house.entity.House
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface HouseRepository : JpaRepository<House, Long>, HouseRepositoryCustom {
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/repository/HouseRepositoryCustom.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/repository/HouseRepositoryCustom.kt
@@ -1,0 +1,10 @@
+package com.example.jhouse_server.domain.house.repository
+
+import com.example.jhouse_server.domain.house.dto.HouseListDto
+import com.example.jhouse_server.domain.house.entity.House
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface HouseRepositoryCustom {
+    fun getHouseAll(houseListDto: HouseListDto, pageable: Pageable) : Page<House>
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/repository/HouseRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/repository/HouseRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.example.jhouse_server.domain.house.repository
+
+import com.example.jhouse_server.domain.house.dto.HouseListDto
+import com.example.jhouse_server.domain.house.entity.House
+import com.example.jhouse_server.domain.house.entity.QHouse.house
+import com.example.jhouse_server.domain.house.entity.RentalType
+import com.example.jhouse_server.domain.user.entity.QUser.user
+import com.querydsl.core.types.Predicate
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
+
+class HouseRepositoryImpl(
+    private var jpaQueryFactory: JPAQueryFactory
+): HouseRepositoryCustom {
+    override fun getHouseAll(houseListDto: HouseListDto, pageable: Pageable) : Page<House> {
+        val result = jpaQueryFactory
+            .selectFrom(house)
+            .join(house.user, user).fetchJoin()
+            .where(house.useYn.eq(true), house.houseType.eq(RentalType.valueOf(houseListDto.rentalType)), filterWithCity(houseListDto.city), searchWithKeyword(houseListDto.search))
+            .limit(pageable.pageSize.toLong())
+            .offset(pageable.offset)
+            .fetch()
+        val countQuery = jpaQueryFactory
+            .selectFrom(house)
+            .where(house.useYn.eq(true), house.houseType.eq(RentalType.valueOf(houseListDto.rentalType)), house.address.city.eq(houseListDto.city))
+        return PageableExecutionUtils.getPage(result, pageable) { countQuery.fetch().size.toLong()}
+    }
+
+    /**
+     * 검색어 필터링 함수
+     * */
+    private fun searchWithKeyword(keyword: String?): BooleanExpression? {
+        return if(keyword == null) null else house.content.contains(keyword).or(house.title.contains(keyword))
+    }
+
+    /**
+     * 지역 필터링 함수
+     * 수도권 -> 서울, 인천, 경기
+     * 그외 -> city
+     * */
+    private fun filterWithCity(city: String?): BooleanExpression? {
+        return if(city == null) null
+        else {
+            if(city == "수도권") house.address.city.contains("서울")
+                .or(house.address.city.contains("인천"))
+                .or(house.address.city.contains("경기"))
+            else house.address.city.contains(city)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/service/HouseService.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/service/HouseService.kt
@@ -1,0 +1,18 @@
+package com.example.jhouse_server.domain.house.service
+
+import com.example.jhouse_server.domain.house.dto.HouseListDto
+import com.example.jhouse_server.domain.house.dto.HouseReqDto
+import com.example.jhouse_server.domain.house.dto.HouseResDto
+import com.example.jhouse_server.domain.house.dto.HouseResOneDto
+import com.example.jhouse_server.domain.user.entity.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface HouseService {
+    fun createHouse(req: HouseReqDto, user: User): Long
+    fun getHouseAll(houseListDto: HouseListDto, pageable: Pageable): Page<HouseResDto>
+    fun updateHouse(houseId: Long, req: HouseReqDto, user: User): Long
+    fun deleteHouse(houseId: Long, user: User)
+    fun getHouseOne(houseId: Long): HouseResOneDto
+
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/house/service/HouseServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/house/service/HouseServiceImpl.kt
@@ -1,0 +1,69 @@
+package com.example.jhouse_server.domain.house.service
+
+import com.example.jhouse_server.domain.board.PrefixCategory
+import com.example.jhouse_server.domain.board.entity.Board
+import com.example.jhouse_server.domain.board.entity.BoardCategory
+import com.example.jhouse_server.domain.board.entity.BoardCode
+import com.example.jhouse_server.domain.board.repository.BoardCodeRepository
+import com.example.jhouse_server.domain.board.repository.BoardRepository
+import com.example.jhouse_server.domain.board.service.getContent
+import com.example.jhouse_server.domain.house.dto.*
+import com.example.jhouse_server.domain.house.entity.Address
+import com.example.jhouse_server.domain.house.entity.House
+import com.example.jhouse_server.domain.house.repository.HouseRepository
+import com.example.jhouse_server.domain.user.entity.Authority
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.domain.user.repository.UserRepository
+import com.example.jhouse_server.global.exception.ApplicationException
+import com.example.jhouse_server.global.exception.ErrorCode
+import com.example.jhouse_server.global.util.findByIdOrThrow
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+@Transactional(readOnly = true)
+class HouseServiceImpl(
+    val houseRepository: HouseRepository,
+    val boardRepository: BoardRepository,
+) : HouseService {
+
+    @Transactional
+    override fun createHouse(req: HouseReqDto, user: User): Long {
+        val address = Address(req.city!!, req.zipCode!!)
+        val content = getContent(req.code!!)
+        val house = House(req.rentalType!!, address, req.size!!, req.purpose!!, req.floorNum,
+            req.sumFloor, req.contact!!, req.createdDate, req.price!!, req.monthlyPrice,
+            req.agentName, req.title, content, req.code, req.imageUrls, user)
+        return houseRepository.save(house).id
+    }
+
+    override fun getHouseAll(houseListDto: HouseListDto, pageable: Pageable): Page<HouseResDto> {
+        return houseRepository.getHouseAll(houseListDto, pageable).map{ toListDto(it) }
+    }
+
+    @Transactional
+    override fun updateHouse(houseId: Long, req: HouseReqDto, user: User): Long {
+        val house = houseRepository.findByIdOrThrow(houseId)
+        house.address.updateEntity(req.city!!, req.zipCode!!)
+        if (user != house.user) throw ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION)
+        val content = getContent(req.code!!)
+        return house.updateEntity(
+            req.rentalType!!, req.size!!, req.purpose!!, req.floorNum, req.sumFloor, req.contact!!,
+            req.createdDate, req.price!!, req.monthlyPrice, req.agentName, req.title, content, req.code, req.imageUrls
+        ).id
+    }
+
+    @Transactional
+    override fun deleteHouse(houseId: Long, user: User) {
+        val house = houseRepository.findByIdOrThrow(houseId)
+        if (user == house.user || user.authority == Authority.ADMIN) house.deleteEntity()
+        else throw ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION)
+    }
+
+    override fun getHouseOne(houseId: Long): HouseResOneDto {
+        return houseRepository.findByIdOrThrow(houseId).run { toDto(this) }
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
@@ -1,7 +1,9 @@
 package com.example.jhouse_server.domain.user.entity
 
 import com.example.jhouse_server.domain.board.entity.Board
+import com.example.jhouse_server.domain.house.entity.Scrap
 import com.example.jhouse_server.domain.comment.entity.Comment
+import com.example.jhouse_server.domain.house.entity.House
 import com.example.jhouse_server.domain.record.entity.Record
 import com.example.jhouse_server.domain.record_comment.entity.RecordComment
 import com.example.jhouse_server.domain.record_review.entity.RecordReview
@@ -40,6 +42,12 @@ class User(
 
     @OneToMany(mappedBy = "user")
     val boards : MutableList<Board> = mutableListOf(),
+
+    @OneToMany(mappedBy = "subscriber")
+    val scraps : MutableList<Scrap> = mutableListOf(),
+
+    @OneToMany(mappedBy = "user")
+    val houses: MutableList<House> = mutableListOf(),
 
     @OneToMany(mappedBy = "user")
     val records : MutableList<Record> = mutableListOf(),

--- a/src/main/kotlin/com/example/jhouse_server/global/aop/CodeValidator.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/aop/CodeValidator.kt
@@ -1,0 +1,53 @@
+package com.example.jhouse_server.global.aop
+
+import com.example.jhouse_server.domain.board.service.getContent
+import com.example.jhouse_server.domain.house.dto.HouseReqDto
+import com.example.jhouse_server.global.exception.ApplicationException
+import com.example.jhouse_server.global.exception.ErrorCode
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.Errors
+import org.springframework.validation.ValidationUtils
+import org.springframework.validation.Validator
+
+@Component
+class CodeValidator: Validator {
+    override fun supports(clazz: Class<*>): Boolean {
+        return HouseReqDto::class.java.isAssignableFrom(clazz)
+    }
+
+    override fun validate(target: Any, errors: Errors) {
+        val houseReqDto: HouseReqDto = target as HouseReqDto
+        if(getContent(houseReqDto.code).length > 10000) errors.rejectValue("code", ErrorCode.LENGTH_OUT_OF_CONTENTS.code, ErrorCode.LENGTH_OUT_OF_CONTENTS.message)
+    }
+}
+
+@Component
+@Aspect
+class ValidatorAspect(private val codeValidator: CodeValidator) {
+
+    @Pointcut("@annotation(EnableValidation)")
+    fun enableValidation() {}
+
+    @Before("enableValidation()")
+    fun beforeValidation() {}
+
+    @AfterReturning(value = "enableValidation()", returning = "result")
+    fun afterValidation(result: Any?) {
+        if (result is HouseReqDto) {
+            val errors = BeanPropertyBindingResult(result, "houseReqDto")
+            ValidationUtils.invokeValidator(codeValidator, result, errors)
+
+            if (errors.hasErrors()) {
+                throw ApplicationException(ErrorCode.INVALID_VALUE_EXCEPTION)
+            }
+        }
+    }
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EnableValidation

--- a/src/main/kotlin/com/example/jhouse_server/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/exception/ErrorCode.kt
@@ -35,4 +35,7 @@ enum class ErrorCode(
 
     // Record
     ALREADY_APPROVE(HttpStatus.BAD_REQUEST, "R0000", "이미 승인처리된 글입니다."),
+
+    // House
+    LENGTH_OUT_OF_CONTENTS(HttpStatus.BAD_REQUEST, "H0000", "빈집 게시글의 내용이 10000자를 넘었습니다."),
 }

--- a/src/main/resources/static/docs/board.html
+++ b/src/main/resources/static/docs/board.html
@@ -451,7 +451,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MjEsImF1dGgiOiJVU0VSIn0.SO5kY0gL8y9r0cjjtEqgWc2DIbVFsiSC3n9IUkxEeRk_kVzv7Mor_Yap9IuMhJfLzkE-2NI9xy8SDfacqryW1w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODEsImF1dGgiOiJVU0VSIn0.1KYs1DHl637XbYAi9hPBTeaBN6w5E1ni3yl7Pmuz4Hpzrutnn1FWZxuly1_sXXG-whAVC8tREeDKwX_1z6h80Q
 Accept: application/json
 Content-Length: 316
 Host: localhost:8080
@@ -482,7 +482,7 @@ Content-Length: 64
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 854
+  "data" : 505
 }</code></pre>
 </div>
 </div>
@@ -495,7 +495,7 @@ Content-Length: 64
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MjEsImF1dGgiOiJVU0VSIn0.SO5kY0gL8y9r0cjjtEqgWc2DIbVFsiSC3n9IUkxEeRk_kVzv7Mor_Yap9IuMhJfLzkE-2NI9xy8SDfacqryW1w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODAsImF1dGgiOiJVU0VSIn0.KL_mXMGLeOAKNphPDQ_iwbCDLzK_O38K5X9Vfq4Nr9h9nuK_a1S6xJABdT10Lu6Ahne2DTsDALDaDbMHRexUfg
 Accept: application/json
 Content-Length: 312
 Host: localhost:8080
@@ -525,7 +525,7 @@ Content-Length: 64
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 852
+  "data" : 503
 }</code></pre>
 </div>
 </div>
@@ -539,7 +539,7 @@ Content-Length: 64
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MTksImF1dGgiOiJVU0VSIn0.-jBm2SjZFCV0dvhVphifuCVVOtCZ8haY-hyllvFp0paTI6KrRv_Awy5vV10ZUa5ACkvNeyspronMs4Rh68oabg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODAsImF1dGgiOiJVU0VSIn0.KL_mXMGLeOAKNphPDQ_iwbCDLzK_O38K5X9Vfq4Nr9h9nuK_a1S6xJABdT10Lu6Ahne2DTsDALDaDbMHRexUfg
 Accept: application/json
 Content-Length: 317
 Host: localhost:8080
@@ -569,7 +569,7 @@ Content-Length: 64
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 847
+  "data" : 498
 }</code></pre>
 </div>
 </div>
@@ -614,12 +614,12 @@ Content-Length: 531
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : [ {
-    "boardId" : 844,
+    "boardId" : 495,
     "title" : "짱구는 못말려",
     "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
     "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
     "nickName" : "테스트유저1",
-    "createdAt" : "2023-06-15T18:18:37.088+00:00",
+    "createdAt" : "2023-06-19T14:59:39.792+00:00",
     "imageUrl" : "img001",
     "commentCount" : 1,
     "category" : "TREND",
@@ -667,12 +667,12 @@ Content-Length: 838
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "boardId" : 848,
+      "boardId" : 499,
       "title" : "짱구는 못말려",
       "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-06-15T18:18:39.955+00:00",
+      "createdAt" : "2023-06-19T14:59:40.647+00:00",
       "imageUrl" : "img001",
       "commentCount" : 1,
       "category" : "TREND",
@@ -681,16 +681,16 @@ Content-Length: 838
     } ],
     "size" : 8,
     "totalElements" : 1,
-    "totalPages" : 1,
     "last" : true,
-    "numberOfElements" : 1,
-    "first" : true,
-    "sort" : {
-      "unsorted" : true,
-      "sorted" : false,
-      "empty" : true
-    },
+    "totalPages" : 1,
     "number" : 0,
+    "sort" : {
+      "empty" : true,
+      "unsorted" : true,
+      "sorted" : false
+    },
+    "first" : true,
+    "numberOfElements" : 1,
     "empty" : false
   }
 }</code></pre>
@@ -704,7 +704,7 @@ Content-Length: 838
 <h5 id="_request_6">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/849 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/500 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -719,27 +719,27 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 648
+Content-Length: 649
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "boardId" : 849,
+    "boardId" : 500,
     "title" : "짱구는 못말려",
     "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
     "nickName" : "테스트유저1",
-    "createdAt" : "2023-06-15T18:18:40.897+00:00",
+    "createdAt" : "2023-06-19T14:59:40.809+00:00",
     "imageUrls" : [ "img001" ],
     "loveCount" : 0,
     "category" : "TREND",
     "prefixCategory" : "INTRO",
     "commentCount" : 1,
     "comments" : [ {
-      "commentId" : 5921,
+      "commentId" : 22200,
       "nickName" : "테스트유저1",
       "content" : "댓글이란다.",
-      "createdAt" : "2023-06-15T18:18:40.909+00:00"
+      "createdAt" : "2023-06-19T14:59:40.814+00:00"
     } ]
   }
 }</code></pre>
@@ -753,9 +753,9 @@ Content-Length: 648
 <h5 id="_request_7">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/boards/850 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/boards/501 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MjEsImF1dGgiOiJVU0VSIn0.SO5kY0gL8y9r0cjjtEqgWc2DIbVFsiSC3n9IUkxEeRk_kVzv7Mor_Yap9IuMhJfLzkE-2NI9xy8SDfacqryW1w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODAsImF1dGgiOiJVU0VSIn0.KL_mXMGLeOAKNphPDQ_iwbCDLzK_O38K5X9Vfq4Nr9h9nuK_a1S6xJABdT10Lu6Ahne2DTsDALDaDbMHRexUfg
 Accept: application/json
 Content-Length: 255
 Host: localhost:8080
@@ -785,7 +785,7 @@ Content-Length: 64
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 850
+  "data" : 501
 }</code></pre>
 </div>
 </div>
@@ -797,8 +797,8 @@ Content-Length: 64
 <h5 id="_request_8">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/boards/845 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MTksImF1dGgiOiJVU0VSIn0.-jBm2SjZFCV0dvhVphifuCVVOtCZ8haY-hyllvFp0paTI6KrRv_Awy5vV10ZUa5ACkvNeyspronMs4Rh68oabg
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/boards/496 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODAsImF1dGgiOiJVU0VSIn0.KL_mXMGLeOAKNphPDQ_iwbCDLzK_O38K5X9Vfq4Nr9h9nuK_a1S6xJABdT10Lu6Ahne2DTsDALDaDbMHRexUfg
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -866,7 +866,7 @@ Content-Length: 168
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-13 19:46:22 +0900
+Last updated 2023-06-04 21:30:35 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/comment.html
+++ b/src/main/resources/static/docs/comment.html
@@ -449,7 +449,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h5 id="_request">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/comments/893 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/comments/544 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -464,16 +464,16 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 217
+Content-Length: 218
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : [ {
-    "commentId" : 6026,
+    "commentId" : 22305,
     "nickName" : "테스트유저1",
     "content" : "댓글이란다.",
-    "createdAt" : "2023-06-15T18:18:49.872+00:00"
+    "createdAt" : "2023-06-19T14:59:43.670+00:00"
   } ]
 }</code></pre>
 </div>
@@ -488,13 +488,13 @@ Content-Length: 217
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzAsImF1dGgiOiJVU0VSIn0.HRB6symgvXozFSGAHB-izpCISqDBqMFmXOxKzT2CxY49QSbFZJ4Jq87UwBSnz18-0EV3S7bl1CW-78nNnML-TQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODMsImF1dGgiOiJVU0VSIn0.EetrqVgSx-roO3dbUsJ5NCZR1RImAOFbVKBd0srKVKrPr1v6J4ieMDeHTEBhq2GyFu2yvIG0wGlw-JKXbaocag
 Accept: application/json
 Content-Length: 64
 Host: localhost:8080
 
 {
-  "boardId" : 895,
+  "boardId" : 546,
   "content" : "짱구야, 공부 하자."
 }</code></pre>
 </div>
@@ -509,12 +509,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6037
+  "data" : 22316
 }</code></pre>
 </div>
 </div>
@@ -526,15 +526,15 @@ Content-Length: 65
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/comments/6030 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/comments/22309 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzAsImF1dGgiOiJVU0VSIn0.HRB6symgvXozFSGAHB-izpCISqDBqMFmXOxKzT2CxY49QSbFZJ4Jq87UwBSnz18-0EV3S7bl1CW-78nNnML-TQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODMsImF1dGgiOiJVU0VSIn0.EetrqVgSx-roO3dbUsJ5NCZR1RImAOFbVKBd0srKVKrPr1v6J4ieMDeHTEBhq2GyFu2yvIG0wGlw-JKXbaocag
 Accept: application/json
 Content-Length: 64
 Host: localhost:8080
 
 {
-  "boardId" : 894,
+  "boardId" : 545,
   "content" : "짱구야, 공부 하자."
 }</code></pre>
 </div>
@@ -549,12 +549,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6030
+  "data" : 22309
 }</code></pre>
 </div>
 </div>
@@ -566,8 +566,8 @@ Content-Length: 65
 <h5 id="_request_4">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/comments/6041 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzAsImF1dGgiOiJVU0VSIn0.HRB6symgvXozFSGAHB-izpCISqDBqMFmXOxKzT2CxY49QSbFZJ4Jq87UwBSnz18-0EV3S7bl1CW-78nNnML-TQ
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/comments/22320 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODMsImF1dGgiOiJVU0VSIn0.EetrqVgSx-roO3dbUsJ5NCZR1RImAOFbVKBd0srKVKrPr1v6J4ieMDeHTEBhq2GyFu2yvIG0wGlw-JKXbaocag
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -597,7 +597,7 @@ Content-Length: 48
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-13 17:32:16 +0900
+Last updated 2023-04-04 02:29:34 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/error.html
+++ b/src/main/resources/static/docs/error.html
@@ -453,7 +453,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1212
+Content-Length: 1290
 
 {
   "code" : "SUCCESS",
@@ -469,6 +469,7 @@ Content-Length: 1212
       "J0003" : "지원되지 않는 JWT 토큰입니다.",
       "C0000" : "예기치 못한 오류가 발생했습니다.",
       "J0002" : "만료된 JWT 토큰입니다.",
+      "H0000" : "빈집 게시글의 내용이 10000자를 넘었습니다.",
       "J0005" : "토큰 검증 실패",
       "J0004" : "JWT 토큰이 잘못되었습니다.",
       "R0000" : "이미 승인처리된 글입니다.",
@@ -490,7 +491,7 @@ Content-Length: 1212
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-20 22:18:31 +0900
+Last updated 2023-05-18 15:44:55 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/house.html
+++ b/src/main/resources/static/docs/house.html
@@ -1,0 +1,463 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>House API</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_house_api">House API</h2>
+<div class="sectionbody">
+<div class="sect3">
+<h4 id="_1_빈집_게시글_작성하기">1. 빈집 게시글 작성하기</h4>
+<div class="sect4">
+<h5 id="_request">Request</h5>
+
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2023-06-19 23:20:33 +0900
+</div>
+</div>
+</body>
+</html>

--- a/src/main/resources/static/docs/house.html
+++ b/src/main/resources/static/docs/house.html
@@ -447,7 +447,850 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_1_빈집_게시글_작성하기">1. 빈집 게시글 작성하기</h4>
 <div class="sect4">
 <h5 id="_request">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/houses HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODQsImF1dGgiOiJVU0VSIn0.hggoot1oxMb282qpr8Vuc4mDag--I56xHaboGz6r8IKHr-AzZph5Yf3MKkZZXprpgM11F10zvH2GSiDIv0VB7Q
+Accept: application/json
+Content-Length: 633
+Host: localhost:8080
 
+{
+  "rentalType" : "SALE",
+  "city" : "서울시 서대문구 남가좌동 거북골로 34",
+  "zipCode" : "12345",
+  "size" : "120909000",
+  "purpose" : "주거용 ( 방3, 화장실 2 )",
+  "floorNum" : 2,
+  "sumFloor" : 3,
+  "contact" : "070-1234-5678",
+  "createdDate" : "1990-09-09",
+  "price" : 12000,
+  "monthlyPrice" : 0.0,
+  "agentName" : "행복부동산",
+  "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
+  "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;행복부동산 최신 매물로&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;주거용 주택&lt;/i&gt;을 소개합니다. &lt;/div&gt; &lt;/body&gt;",
+  "imageUrls" : [ "img-001", "img-002" ]
+}</code></pre>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_request_fields">Request fields</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>rentalType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매매 타입 ( SALE(매매), JEONSE(전세), MONTHLYRENT(월세) )은 필수값입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>city</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주소는 '시도&#8217;로 시작하되, 줄이지 않은 표현으로 작성해야 합니다. 예: 서울시 서대문구 거북골로 34</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>zipCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">우편번호 ( string 형식입니다. )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">집 크기는 m^2 단위로 산정해서 작성해야 합니다. string 형식입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>purpose</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 목적/용도 예: 거주 ( 방3, 화장실 2 )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>floorNum</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물이 위치한 층수 ( 단독주택인 경우, null 로 전달 시 서버에서 0으로 세팅 )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sumFloor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물이 위치한 건물의 총 층수 ( 단독주택인 경우, 단독주택이 갖는 층수를 작성할 것 )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contact</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">연락 가능한 연락처를 01000000000 형식으로 작성</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">준공연도는 숫자만 입력해주세요. YYYY 형태로 서버에서 관리합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물가격은 만원 단위로 산정해서 작성해주세요. ( 월세의 경우, 보증금을 작성해주세요. )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>monthlyPrice</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">월세 가격은 만원 단위로 산정해서 소수점 포함으로 작성해주세요. Double 형식으로 관리합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>agentName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사명을 작성해주세요. ( 없는 경우, 서버에서 null로 관리합니다. )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글의 제목을 입력해주세요.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글의 내용을 입력해주세요.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrls</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 주소를 string 배열 형식으로 입력해주세요.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 64
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공",
+  "data" : 578
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_fields">Response fields</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_2_빈집_게시글_수정하기">2. 빈집 게시글 수정하기</h4>
+<div class="sect4">
+<h5 id="_request_2">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/577 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODQsImF1dGgiOiJVU0VSIn0.hggoot1oxMb282qpr8Vuc4mDag--I56xHaboGz6r8IKHr-AzZph5Yf3MKkZZXprpgM11F10zvH2GSiDIv0VB7Q
+Accept: application/json
+Content-Length: 656
+Host: localhost:8080
+
+{
+  "rentalType" : "JEONSE",
+  "city" : "서울시 서대문구 남가좌동 거북골로 90",
+  "zipCode" : "12345",
+  "size" : "120909000",
+  "purpose" : "게스트하우스 ( 방3, 화장실 2 )",
+  "floorNum" : 2,
+  "sumFloor" : 3,
+  "contact" : "070-1234-5678",
+  "createdDate" : "1990-09-09",
+  "price" : 12000,
+  "monthlyPrice" : 0.0,
+  "agentName" : "부자부동산",
+  "title" : "부자부동산에서 제공하는 서울시 빈집 매물입니다.",
+  "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;부자부동산 최신 매물로&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;게스트하우스용 주택&lt;/i&gt;을 소개합니다. &lt;/div&gt; &lt;/body&gt;",
+  "imageUrls" : [ "img-001", "img-002" ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_request_fields_2">Request Fields</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>rentalType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매매 타입 ( SALE(매매), JEONSE(전세), MONTHLYRENT(월세) )은 필수값입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>city</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주소는 '시도&#8217;로 시작하되, 줄이지 않은 표현으로 작성해야 합니다. 예: 서울시 서대문구 거북골로 34</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>zipCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">우편번호 ( string 형식입니다. )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">집 크기는 m^2 단위로 산정해서 작성해야 합니다. string 형식입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>purpose</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 목적/용도 예: 거주 ( 방3, 화장실 2 )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>floorNum</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물이 위치한 층수 ( 단독주택인 경우, null 로 전달 시 서버에서 0으로 세팅 )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sumFloor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물이 위치한 건물의 총 층수 ( 단독주택인 경우, 단독주택이 갖는 층수를 작성할 것 )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>contact</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">연락 가능한 연락처를 01000000000 형식으로 작성</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">준공연도는 숫자만 입력해주세요. YYYY 형태로 서버에서 관리합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물가격은 만원 단위로 산정해서 작성해주세요. ( 월세의 경우, 보증금을 작성해주세요. )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>monthlyPrice</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">월세 가격은 만원 단위로 산정해서 소수점 포함으로 작성해주세요. Double 형식으로 관리합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>agentName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사명을 작성해주세요. ( 없는 경우, 서버에서 null로 관리합니다. )</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글의 제목을 입력해주세요.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글의 내용을 입력해주세요.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>imageUrls</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 주소를 string 배열 형식으로 입력해주세요.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_response_2">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 64
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공",
+  "data" : 577
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_3_빈집_게시글_삭제하기">3. 빈집 게시글 삭제하기</h4>
+<div class="paragraph">
+<p>삭제 시, 빈집 게시글 아이디를 path-variable로 넘겨주세요.</p>
+</div>
+<div class="sect4">
+<h5 id="_request_3">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/houses/576 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODQsImF1dGgiOiJVU0VSIn0.hggoot1oxMb282qpr8Vuc4mDag--I56xHaboGz6r8IKHr-AzZph5Yf3MKkZZXprpgM11F10zvH2GSiDIv0VB7Q
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_3">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 48
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_4_빈집_게시글_목록_조회">4. 빈집 게시글 목록 조회</h4>
+<div class="sect4">
+<h5 id="_request_4">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses?rentalType=SALE&amp;city=%EC%84%9C%EC%9A%B8&amp;search= HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_request_fields_3">Request Fields</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>rentalType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매매 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>city</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지역 필터링</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>search</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색어</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_response_4">Response</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 2991
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공",
+  "data" : {
+    "content" : [ {
+      "houseId" : 1,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 150000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "짱구",
+      "createdAt" : "2023-06-19T13:31:22.000+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 579,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.448+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 581,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.451+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 583,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.454+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 585,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.456+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 587,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.459+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 589,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.461+00:00",
+      "isCompleted" : false
+    }, {
+      "houseId" : 591,
+      "rentalType" : "SALE",
+      "city" : "서울시 서대문구 남가좌동 거북골로 34",
+      "price" : 12000,
+      "monthlyPrice" : 0.0,
+      "nickName" : "테스트유저1",
+      "createdAt" : "2023-06-19T14:59:44.463+00:00",
+      "isCompleted" : false
+    } ],
+    "pageable" : {
+      "sort" : {
+        "empty" : true,
+        "unsorted" : true,
+        "sorted" : false
+      },
+      "offset" : 0,
+      "pageNumber" : 0,
+      "pageSize" : 8,
+      "unpaged" : false,
+      "paged" : true
+    },
+    "last" : true,
+    "totalPages" : 1,
+    "totalElements" : 8,
+    "number" : 0,
+    "sort" : {
+      "empty" : true,
+      "unsorted" : true,
+      "sorted" : false
+    },
+    "size" : 8,
+    "first" : true,
+    "numberOfElements" : 8,
+    "empty" : false
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_response_fields_2">Response Fields</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].houseId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].rentalType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매매 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].city</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 위치</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].monthlyPrice</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">월세 가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].nickName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].isCompleted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">거래 완료 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.sort.empty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.sort.unsorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.sort.sorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.offset</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.pageNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.pageSize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.unpaged</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageable.paged</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort.empty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort.unsorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort.sorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>first</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>numberOfElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>empty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_5_빈집_게시글_단일_조회">5. 빈집 게시글 단일 조회</h5>
+<div class="sect5">
+<h6 id="_request_5">Request</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/601 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_response_5">Response</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 836
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공",
+  "data" : {
+    "houseId" : 601,
+    "rentalType" : "SALE",
+    "city" : "서울시 서대문구 남가좌동 거북골로 34",
+    "zipcode" : "12345",
+    "purpose" : "주거용 ( 방3, 화장실 2 )",
+    "floorNum" : 2,
+    "sumFloor" : 3,
+    "contact" : "070-1234-5678",
+    "createdDate" : "1990-09-09",
+    "price" : 12000,
+    "monthlyPrice" : 0.0,
+    "agentName" : "행복부동산",
+    "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
+    "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;행복부동산 최신 매물로&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;주거용 주택&lt;/i&gt;을 소개합니다. &lt;/div&gt; &lt;/body&gt;",
+    "imageUrls" : [ "img-001", "img-002" ],
+    "nickName" : "테스트유저1",
+    "createdAt" : "2023-06-19T14:59:44.559+00:00",
+    "isCompleted" : false
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_response_fields_3">Response Fields</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.houseId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">빈집 게시글 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.rentalType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.city</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 위치</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.zipcode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">우편 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.purpose</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 목적/용도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.floorNum</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 층수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.sumFloor</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물이 위치한 건물 총 층수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.contact</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">연락 가능한 연락처</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">준공연도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.monthlyPrice</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">월세 가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.agentName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.imageUrls</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 이미지 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.nickName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.isCompleted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">매물 거래 완료 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 </div>
 </div>
@@ -456,7 +1299,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-19 23:20:33 +0900
+Last updated 2023-06-19 23:28:18 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/jwt.html
+++ b/src/main/resources/static/docs/jwt.html
@@ -519,7 +519,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-13 17:32:16 +0900
+Last updated 2023-04-04 02:29:34 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/love.html
+++ b/src/main/resources/static/docs/love.html
@@ -449,8 +449,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h5 id="_request">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/loves/902 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzEsImF1dGgiOiJVU0VSIn0.iCGqpXcGk7d1HB4t44FG-wQYjDmBPzvae7s7VI0iKoDvDlwWL0R-7xirHNGbiZylYDz92S9H86W1zKtuSswdwQ
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/loves/553 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODQsImF1dGgiOiJVU0VSIn0.hggoot1oxMb282qpr8Vuc4mDag--I56xHaboGz6r8IKHr-AzZph5Yf3MKkZZXprpgM11F10zvH2GSiDIv0VB7Q
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -470,7 +470,7 @@ Content-Length: 64
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 902
+  "data" : 553
 }</code></pre>
 </div>
 </div>
@@ -482,8 +482,8 @@ Content-Length: 64
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/loves/905 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzEsImF1dGgiOiJVU0VSIn0.iCGqpXcGk7d1HB4t44FG-wQYjDmBPzvae7s7VI0iKoDvDlwWL0R-7xirHNGbiZylYDz92S9H86W1zKtuSswdwQ
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/loves/556 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODQsImF1dGgiOiJVU0VSIn0.hggoot1oxMb282qpr8Vuc4mDag--I56xHaboGz6r8IKHr-AzZph5Yf3MKkZZXprpgM11F10zvH2GSiDIv0VB7Q
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -514,8 +514,8 @@ Content-Length: 48
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/loves/906 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzEsImF1dGgiOiJVU0VSIn0.iCGqpXcGk7d1HB4t44FG-wQYjDmBPzvae7s7VI0iKoDvDlwWL0R-7xirHNGbiZylYDz92S9H86W1zKtuSswdwQ
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/loves/557 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODQsImF1dGgiOiJVU0VSIn0.hggoot1oxMb282qpr8Vuc4mDag--I56xHaboGz6r8IKHr-AzZph5Yf3MKkZZXprpgM11F10zvH2GSiDIv0VB7Q
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -547,7 +547,7 @@ Content-Length: 66
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-13 17:32:16 +0900
+Last updated 2023-04-04 02:29:34 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/record.html
+++ b/src/main/resources/static/docs/record.html
@@ -470,7 +470,7 @@ tech - architecture</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzUsImF1dGgiOiJBRE1JTiJ9.j86DuH6LP0dCF4bSkYHH24bOEwyLkWTRk6dJHpEfo853Fh04yzOacJFhYAjssZW-uecD5PqrAz1O5NnYVuT91g
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODYsImF1dGgiOiJBRE1JTiJ9.W3MWa0lq2Q3RUF9RE0iOGDdiOG3-pq3pLk83p_M_L7_WpFDd7ZR00hvME-sA6Wcc8z2gQuP95nb8TZz9Vh3lUQ
 Accept: application/json
 Content-Length: 189
 Host: localhost:8080
@@ -494,12 +494,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6289
+  "data" : 22583
 }</code></pre>
 </div>
 </div>
@@ -511,9 +511,9 @@ Content-Length: 65
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record/6149 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record/22443 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzMsImF1dGgiOiJBRE1JTiJ9.B51wJB-cAcXbMt593s-xrKRaZkDSPrWNtvlnWj8eYDwqi73KnAuUcesSwzOkV_LgmaYhNiUrIBp3G5E7Ok-6LA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODUsImF1dGgiOiJBRE1JTiJ9.VRAINnEO07yekTdLT63DSWOMukc0bXFr1KU2JeKBiDSdmpp5cG2r22-PlvgVW8n0LvRVcPDy4G2Sn7bDgMqO_A
 Accept: application/json
 Content-Length: 62
 Host: localhost:8080
@@ -534,12 +534,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6149
+  "data" : 22443
 }</code></pre>
 </div>
 </div>
@@ -551,9 +551,9 @@ Content-Length: 65
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record/6196 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record/22490 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzMsImF1dGgiOiJBRE1JTiJ9.B51wJB-cAcXbMt593s-xrKRaZkDSPrWNtvlnWj8eYDwqi73KnAuUcesSwzOkV_LgmaYhNiUrIBp3G5E7Ok-6LA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODUsImF1dGgiOiJBRE1JTiJ9.VRAINnEO07yekTdLT63DSWOMukc0bXFr1KU2JeKBiDSdmpp5cG2r22-PlvgVW8n0LvRVcPDy4G2Sn7bDgMqO_A
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -600,20 +600,20 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 325
+Content-Length: 328
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
     "records" : [ {
-      "record_id" : 6229,
+      "record_id" : 22523,
       "title" : "코드 리뷰 문화 도입"
     }, {
-      "record_id" : 6232,
+      "record_id" : 22526,
       "title" : "DDOS 대응 회고"
     }, {
-      "record_id" : 6235,
+      "record_id" : 22529,
       "title" : "인증 인가 직접 구현하기"
     } ]
   }
@@ -674,7 +674,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1286
+Content-Length: 1288
 
 {
   "code" : "SUCCESS",
@@ -682,44 +682,44 @@ Content-Length: 1286
   "data" : {
     "records" : {
       "content" : [ {
-        "record_id" : 6304,
+        "record_id" : 22598,
         "title" : "인증 인가 직접 구현하기",
         "content" : "스프링 시큐리티를 사용하지 않고, 인증 인가를 직접 구현했습니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "06.16.2023",
+        "create_at" : "06.19.2023",
         "part" : "server"
       }, {
-        "record_id" : 6307,
+        "record_id" : 22601,
         "title" : "인증 인가 직접 구현하기",
         "content" : "스프링 시큐리티를 사용하지 않고, 인증 인가를 직접 구현했습니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "06.16.2023",
+        "create_at" : "06.19.2023",
         "part" : "server"
       } ],
       "pageable" : {
         "sort" : {
+          "empty" : true,
           "unsorted" : true,
-          "sorted" : false,
-          "empty" : true
+          "sorted" : false
         },
-        "pageSize" : 4,
-        "pageNumber" : 0,
         "offset" : 0,
-        "paged" : true,
-        "unpaged" : false
+        "pageNumber" : 0,
+        "pageSize" : 4,
+        "unpaged" : false,
+        "paged" : true
       },
-      "totalElements" : 2,
-      "totalPages" : 1,
       "last" : true,
-      "numberOfElements" : 2,
-      "first" : true,
-      "sort" : {
-        "unsorted" : true,
-        "sorted" : false,
-        "empty" : true
-      },
+      "totalPages" : 1,
+      "totalElements" : 2,
       "number" : 0,
+      "sort" : {
+        "empty" : true,
+        "unsorted" : true,
+        "sorted" : false
+      },
       "size" : 4,
+      "first" : true,
+      "numberOfElements" : 2,
       "empty" : false
     }
   }
@@ -744,7 +744,7 @@ Content-Length: 1286
 <h5 id="_request_6">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/6250?page=0 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/22544?page=0 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -760,13 +760,13 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1506
+Content-Length: 1510
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "record_id" : 6250,
+    "record_id" : 22544,
     "title" : "코드 리뷰 문화 도입",
     "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
     "hits" : 1,
@@ -774,51 +774,51 @@ Content-Length: 1506
     "type" : "odori",
     "category" : "culture",
     "nick_name" : "테스트유저2",
-    "create_at" : "06.16.2023",
+    "create_at" : "06.19.2023",
     "comments" : {
       "content" : [ {
-        "comment_id" : 6265,
+        "comment_id" : 22559,
         "level" : 1,
         "content" : "댓글입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "06.16.2023"
+        "create_at" : "06.19.2023"
       }, {
-        "comment_id" : 6267,
+        "comment_id" : 22561,
         "level" : 2,
         "content" : "댓글입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "06.16.2023"
+        "create_at" : "06.19.2023"
       }, {
-        "comment_id" : 6266,
+        "comment_id" : 22560,
         "level" : 1,
         "content" : "댓글입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "06.16.2023"
+        "create_at" : "06.19.2023"
       } ],
       "pageable" : {
         "sort" : {
+          "empty" : true,
           "unsorted" : true,
-          "sorted" : false,
-          "empty" : true
+          "sorted" : false
         },
-        "pageSize" : 10,
-        "pageNumber" : 0,
         "offset" : 0,
-        "paged" : true,
-        "unpaged" : false
+        "pageNumber" : 0,
+        "pageSize" : 10,
+        "unpaged" : false,
+        "paged" : true
       },
-      "totalElements" : 3,
-      "totalPages" : 1,
       "last" : true,
-      "numberOfElements" : 3,
-      "first" : true,
-      "sort" : {
-        "unsorted" : true,
-        "sorted" : false,
-        "empty" : true
-      },
+      "totalPages" : 1,
+      "totalElements" : 3,
       "number" : 0,
+      "sort" : {
+        "empty" : true,
+        "unsorted" : true,
+        "sorted" : false
+      },
       "size" : 10,
+      "first" : true,
+      "numberOfElements" : 3,
       "empty" : false
     }
   }
@@ -840,9 +840,9 @@ reviewers : 리뷰 신청자 (approve - 승인, reject - 반려, wait - 대기)<
 <h5 id="_request_7">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/review/6205 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/review/22499 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzQsImF1dGgiOiJBRE1JTiJ9.VeQbGJIMgFbzEOjZw9_PM13t_qzuwb7-ckCLvrX8jAqwva5MxQpknUyHP0KYpb8RRjqwjPXEXTmySOxUQefsGA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODUsImF1dGgiOiJBRE1JTiJ9.VRAINnEO07yekTdLT63DSWOMukc0bXFr1KU2JeKBiDSdmpp5cG2r22-PlvgVW8n0LvRVcPDy4G2Sn7bDgMqO_A
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -857,37 +857,37 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 978
+Content-Length: 982
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "record_id" : 6205,
+    "record_id" : 22499,
     "title" : "코드 리뷰 문화 도입",
     "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
     "hits" : 0,
     "part" : "server",
     "nick_name" : "테스트유저2",
-    "create_at" : "06.16.2023",
+    "create_at" : "06.19.2023",
     "reviews" : [ {
-      "review_id" : 6220,
+      "review_id" : 22514,
       "content" : "이 부분 수정해주세요.",
       "status" : "reject",
       "nick_name" : "테스트유저1",
-      "create_at" : "06.16.2023"
+      "create_at" : "06.19.2023"
     }, {
-      "review_id" : 6221,
+      "review_id" : 22515,
       "content" : "수정했습니다.",
       "status" : "mine",
       "nick_name" : "테스트유저2",
-      "create_at" : "06.16.2023"
+      "create_at" : "06.19.2023"
     }, {
-      "review_id" : 6222,
+      "review_id" : 22516,
       "content" : "확인했습니다!",
       "status" : "approve",
       "nick_name" : "테스트유저1",
-      "create_at" : "06.16.2023"
+      "create_at" : "06.19.2023"
     } ],
     "reviewers" : [ {
       "status" : "approve",
@@ -917,7 +917,7 @@ reject : 내가 작성한 글 중 반려 처리된 글</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/reviewee?status=wait&amp;page=0 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzIsImF1dGgiOiJBRE1JTiJ9.4h7pXKM9uBur5hUtvAAsMH35UPX4XZC5z_T_aCnXVWN38pjXsCXqCVTStw7S5gqR-MgyHULs2_pPVqKnBS2unw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODUsImF1dGgiOiJBRE1JTiJ9.VRAINnEO07yekTdLT63DSWOMukc0bXFr1KU2JeKBiDSdmpp5cG2r22-PlvgVW8n0LvRVcPDy4G2Sn7bDgMqO_A
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -932,7 +932,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1451
+Content-Length: 1454
 
 {
   "code" : "SUCCESS",
@@ -940,51 +940,51 @@ Content-Length: 1451
   "data" : {
     "records" : {
       "content" : [ {
-        "record_id" : 6125,
-        "title" : "이슈 제목",
-        "content" : "이슈 내용입니다.",
-        "nick_name" : "테스트유저1",
-        "create_at" : "06.16.2023",
-        "part" : "server"
-      }, {
-        "record_id" : 6119,
+        "record_id" : 22413,
         "title" : "코드 리뷰 문화 도입",
         "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "06.16.2023",
+        "create_at" : "06.19.2023",
         "part" : "server"
       }, {
-        "record_id" : 6122,
+        "record_id" : 22416,
         "title" : "DDOS 대응 회고",
         "content" : "DDOS 공격을 방지하기 위해 Bucket4j 라이브러리를 도입했습니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "06.16.2023",
+        "create_at" : "06.19.2023",
+        "part" : "server"
+      }, {
+        "record_id" : 22419,
+        "title" : "이슈 제목",
+        "content" : "이슈 내용입니다.",
+        "nick_name" : "테스트유저1",
+        "create_at" : "06.19.2023",
         "part" : "server"
       } ],
       "pageable" : {
         "sort" : {
+          "empty" : true,
           "unsorted" : true,
-          "sorted" : false,
-          "empty" : true
+          "sorted" : false
         },
-        "pageSize" : 3,
-        "pageNumber" : 0,
         "offset" : 0,
-        "paged" : true,
-        "unpaged" : false
+        "pageNumber" : 0,
+        "pageSize" : 3,
+        "unpaged" : false,
+        "paged" : true
       },
-      "totalElements" : 3,
-      "totalPages" : 1,
       "last" : true,
-      "numberOfElements" : 3,
-      "first" : true,
-      "sort" : {
-        "unsorted" : true,
-        "sorted" : false,
-        "empty" : true
-      },
+      "totalPages" : 1,
+      "totalElements" : 3,
       "number" : 0,
+      "sort" : {
+        "empty" : true,
+        "unsorted" : true,
+        "sorted" : false
+      },
       "size" : 3,
+      "first" : true,
+      "numberOfElements" : 3,
       "empty" : false
     }
   }
@@ -1011,7 +1011,7 @@ reject : 내가 반려 처리한 글</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/reviewer?status=approve&amp;page=0 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzMsImF1dGgiOiJBRE1JTiJ9.B51wJB-cAcXbMt593s-xrKRaZkDSPrWNtvlnWj8eYDwqi73KnAuUcesSwzOkV_LgmaYhNiUrIBp3G5E7Ok-6LA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODUsImF1dGgiOiJBRE1JTiJ9.VRAINnEO07yekTdLT63DSWOMukc0bXFr1KU2JeKBiDSdmpp5cG2r22-PlvgVW8n0LvRVcPDy4G2Sn7bDgMqO_A
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1026,7 +1026,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1226
+Content-Length: 1228
 
 {
   "code" : "SUCCESS",
@@ -1034,44 +1034,44 @@ Content-Length: 1226
   "data" : {
     "records" : {
       "content" : [ {
-        "record_id" : 6158,
+        "record_id" : 22452,
         "title" : "코드 리뷰 문화 도입",
         "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "06.16.2023",
+        "create_at" : "06.19.2023",
         "part" : "server"
       }, {
-        "record_id" : 6161,
+        "record_id" : 22455,
         "title" : "DDOS 대응 회고",
         "content" : "DDOS 공격을 방지하기 위해 Bucket4j 라이브러리를 도입했습니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "06.16.2023",
+        "create_at" : "06.19.2023",
         "part" : "server"
       } ],
       "pageable" : {
         "sort" : {
+          "empty" : true,
           "unsorted" : true,
-          "sorted" : false,
-          "empty" : true
+          "sorted" : false
         },
-        "pageSize" : 3,
-        "pageNumber" : 0,
         "offset" : 0,
-        "paged" : true,
-        "unpaged" : false
+        "pageNumber" : 0,
+        "pageSize" : 3,
+        "unpaged" : false,
+        "paged" : true
       },
-      "totalElements" : 2,
-      "totalPages" : 1,
       "last" : true,
-      "numberOfElements" : 2,
-      "first" : true,
-      "sort" : {
-        "unsorted" : true,
-        "sorted" : false,
-        "empty" : true
-      },
+      "totalPages" : 1,
+      "totalElements" : 2,
       "number" : 0,
+      "sort" : {
+        "empty" : true,
+        "unsorted" : true,
+        "sorted" : false
+      },
       "size" : 3,
+      "first" : true,
+      "numberOfElements" : 2,
       "empty" : false
     }
   }
@@ -1086,7 +1086,7 @@ Content-Length: 1226
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-23 23:06:43 +0900
+Last updated 2023-05-25 14:02:45 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/record_category.html
+++ b/src/main/resources/static/docs/record_category.html
@@ -463,7 +463,7 @@ architecture (기술 - 설계)</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record_category/template HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzcsImF1dGgiOiJBRE1JTiJ9.0aXVA4r4lFg1dG9SXYaYOZbxbha0P-NFHrCV_8-HL_djWt6qLnL40uHTNopxC8u1wwXpNSRhWXf7pAHqIWxxXA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODcsImF1dGgiOiJBRE1JTiJ9.mxrJHMYAVbnQV6iWwSFN2XotBQqeXtrj7cr9IhtfP3o8xL_MpM9OzSxksiSiH2yFMAhLFN5bOBrpXNWzUNcPNA
 Accept: application/json
 Content-Length: 67
 Host: localhost:8080
@@ -502,7 +502,7 @@ Content-Length: 48
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record_category/template/culture HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzgsImF1dGgiOiJBRE1JTiJ9.Xwfboq6EndT_FHO-FKxYYxFEMlHxdafuk2Isq_PCZWeXu7K-B-DjELfM0ZX8j8ezDwaNE7rPvdBFwtKreQF5zQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODcsImF1dGgiOiJBRE1JTiJ9.mxrJHMYAVbnQV6iWwSFN2XotBQqeXtrj7cr9IhtfP3o8xL_MpM9OzSxksiSiH2yFMAhLFN5bOBrpXNWzUNcPNA
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -537,7 +537,7 @@ Content-Length: 134
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-23 23:06:43 +0900
+Last updated 2023-05-25 14:02:45 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/record_comment.html
+++ b/src/main/resources/static/docs/record_comment.html
@@ -456,13 +456,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record_comment HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzgsImF1dGgiOiJVU0VSIn0.jYm0Hb9pQshyAfhSLmCMkvDtjOPaWdlKThb2vropfSIPfl7c0UGNyyzERnXgndZUG8PDhbfkLewMoBw3M9WVnw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODgsImF1dGgiOiJVU0VSIn0.2cXiw4NggeGwUfU3zvsaiTBSw00r4RwCP4AybolMSo4CoM6B_VtKyW5cMQpS1JBHvBQ_guFPK6P80_A3J3YWbg
 Accept: application/json
-Content-Length: 80
+Content-Length: 81
 Host: localhost:8080
 
 {
-  "record_id" : 6432,
+  "record_id" : 22726,
   "parent_id" : null,
   "content" : "댓글입니다."
 }</code></pre>
@@ -478,12 +478,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6434
+  "data" : 22728
 }</code></pre>
 </div>
 </div>
@@ -495,9 +495,9 @@ Content-Length: 65
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_comment/6425 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_comment/22719 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzgsImF1dGgiOiJVU0VSIn0.jYm0Hb9pQshyAfhSLmCMkvDtjOPaWdlKThb2vropfSIPfl7c0UGNyyzERnXgndZUG8PDhbfkLewMoBw3M9WVnw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODgsImF1dGgiOiJVU0VSIn0.2cXiw4NggeGwUfU3zvsaiTBSw00r4RwCP4AybolMSo4CoM6B_VtKyW5cMQpS1JBHvBQ_guFPK6P80_A3J3YWbg
 Accept: application/json
 Content-Length: 33
 Host: localhost:8080
@@ -517,12 +517,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6425
+  "data" : 22719
 }</code></pre>
 </div>
 </div>
@@ -534,9 +534,9 @@ Content-Length: 65
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_comment/6416 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_comment/22710 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzgsImF1dGgiOiJVU0VSIn0.jYm0Hb9pQshyAfhSLmCMkvDtjOPaWdlKThb2vropfSIPfl7c0UGNyyzERnXgndZUG8PDhbfkLewMoBw3M9WVnw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODgsImF1dGgiOiJVU0VSIn0.2cXiw4NggeGwUfU3zvsaiTBSw00r4RwCP4AybolMSo4CoM6B_VtKyW5cMQpS1JBHvBQ_guFPK6P80_A3J3YWbg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -567,7 +567,7 @@ Content-Length: 48
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-23 23:06:43 +0900
+Last updated 2023-05-25 14:02:45 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/record_review.html
+++ b/src/main/resources/static/docs/record_review.html
@@ -460,13 +460,13 @@ mine (레코드 작성자가 리뷰를 달 때)</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record_review HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzksImF1dGgiOiJBRE1JTiJ9.mI1nuZ99T2-2OEr4gJTL_EfY7cB6Ft8WDj6SWu1MuWDM-DTHnTrqYEyk7jGGBb9WJh7Wo80GRBzY3plQFchKfg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODgsImF1dGgiOiJBRE1JTiJ9.t7_CZPZXkYK0HB9JKTVqLdaW6ImtSO268ojY2dl0FlHSYQlY-dTd95Sep3wQBarEFz8PhXu72aLP0jtP6blmIA
 Accept: application/json
-Content-Length: 93
+Content-Length: 94
 Host: localhost:8080
 
 {
-  "record_id" : 6466,
+  "record_id" : 22760,
   "content" : "좋은 글 감사합니다!",
   "status" : "approve"
 }</code></pre>
@@ -482,12 +482,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6469
+  "data" : 22763
 }</code></pre>
 </div>
 </div>
@@ -517,9 +517,9 @@ Content-Length: 76
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_review/6499 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_review/22793 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzksImF1dGgiOiJBRE1JTiJ9.mI1nuZ99T2-2OEr4gJTL_EfY7cB6Ft8WDj6SWu1MuWDM-DTHnTrqYEyk7jGGBb9WJh7Wo80GRBzY3plQFchKfg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODgsImF1dGgiOiJBRE1JTiJ9.t7_CZPZXkYK0HB9JKTVqLdaW6ImtSO268ojY2dl0FlHSYQlY-dTd95Sep3wQBarEFz8PhXu72aLP0jtP6blmIA
 Accept: application/json
 Content-Length: 57
 Host: localhost:8080
@@ -540,12 +540,12 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 65
+Content-Length: 66
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6499
+  "data" : 22793
 }</code></pre>
 </div>
 </div>
@@ -575,9 +575,9 @@ Content-Length: 76
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_review/6479 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_review/22773 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5MzksImF1dGgiOiJBRE1JTiJ9.mI1nuZ99T2-2OEr4gJTL_EfY7cB6Ft8WDj6SWu1MuWDM-DTHnTrqYEyk7jGGBb9WJh7Wo80GRBzY3plQFchKfg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODgsImF1dGgiOiJBRE1JTiJ9.t7_CZPZXkYK0HB9JKTVqLdaW6ImtSO268ojY2dl0FlHSYQlY-dTd95Sep3wQBarEFz8PhXu72aLP0jtP6blmIA
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -626,7 +626,7 @@ Content-Length: 76
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-23 23:06:43 +0900
+Last updated 2023-05-25 14:02:45 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -575,7 +575,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODc0NTc5NDF9.6FrQuEJnJNOfkxOyCSnpi0do1WIhZJ9K439PEbQg2iSm-9tbd1Bgi68fswHmdEfDfp_GpiuQQ8neltrGQ-pYzw; Path=/; Domain=localhost; Max-Age=604800; Expires=Thu, 22 Jun 2023 18:19:01 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODc3OTE1ODl9.9oSBCJ9TLYJtBVXbM2KL34kyClgmnI-TkHHHDl-Mn6UGhpMgsx-gVA3806Dq3CLKyQT4erxtH101NmZlhb6AQw; Path=/; Domain=localhost; Max-Age=604800; Expires=Mon, 26 Jun 2023 14:59:49 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 280
 
@@ -583,7 +583,7 @@ Content-Length: 280
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDEsImF1dGgiOiJVU0VSIn0.vNmQkVyTOaGCjrfWrxs6aDmgbjdcWzfCmAna6j0RlYWKHAljGDuzVsnl_k2Vn4McNwF7Lh6H3Tp_gDogSlr6Ag"
+    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODksImF1dGgiOiJVU0VSIn0.W8cPqtnC5KZux-bCPCE9XogUlVbmtH8Z-4skyZiFWQdOcklkeBj8Gt2bQGwUul_MKlWueKPhR46HilvmzKVl5g"
   }
 }</code></pre>
 </div>
@@ -664,10 +664,10 @@ Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Content-Length: 215
 Host: localhost:8080
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDIsImF1dGgiOiJVU0VSIn0.VjfHQPA28mvka_RFe8OT8wEwy8KMFSDwMTlwuQdFRdz5oWlY2J5Zie_CMXVmiRv4Y0K0p4B8JsuTwCSvvXnuBQ
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1OTAsImF1dGgiOiJVU0VSIn0.gj8GyNDpbcu5e_apl_C7kueH8HI66Qsw1g_SyI7AzaZZwr_FzcvvPP3s3tszN2FfgXr8JuQKnyW1IvrlJv2ITg
 
 {
-  "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDIsImF1dGgiOiJVU0VSIn0.VjfHQPA28mvka_RFe8OT8wEwy8KMFSDwMTlwuQdFRdz5oWlY2J5Zie_CMXVmiRv4Y0K0p4B8JsuTwCSvvXnuBQ"
+  "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1OTAsImF1dGgiOiJVU0VSIn0.gj8GyNDpbcu5e_apl_C7kueH8HI66Qsw1g_SyI7AzaZZwr_FzcvvPP3s3tszN2FfgXr8JuQKnyW1IvrlJv2ITg"
 }</code></pre>
 </div>
 </div>
@@ -680,7 +680,7 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleH
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODc0NTc5NDJ9.9wHkG_EgRPStlWnSTMKh0YaMmQdK42iXgO4L_q8mGngFMjpV1Mjbiv4sGzvQaj9qBVsHHFZOB2j9M6sGAp3LRA; Path=/; Domain=localhost; Max-Age=604800; Expires=Thu, 22 Jun 2023 18:19:02 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODc3OTE1OTB9.PIR_J5lRJUNlVaSuPUcczEVo9T6BcAki37OyQ7QtzIQfDfX6dXuG3cOJQZf_xCHFHG4XbjZxqmRtXnCzOMLgzQ; Path=/; Domain=localhost; Max-Age=604800; Expires=Mon, 26 Jun 2023 14:59:50 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 280
 
@@ -688,7 +688,7 @@ Content-Length: 280
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDIsImF1dGgiOiJVU0VSIn0.VjfHQPA28mvka_RFe8OT8wEwy8KMFSDwMTlwuQdFRdz5oWlY2J5Zie_CMXVmiRv4Y0K0p4B8JsuTwCSvvXnuBQ"
+    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1OTAsImF1dGgiOiJVU0VSIn0.gj8GyNDpbcu5e_apl_C7kueH8HI66Qsw1g_SyI7AzaZZwr_FzcvvPP3s3tszN2FfgXr8JuQKnyW1IvrlJv2ITg"
   }
 }</code></pre>
 </div>
@@ -702,7 +702,7 @@ Content-Length: 280
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/logout HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDEsImF1dGgiOiJVU0VSIn0.vNmQkVyTOaGCjrfWrxs6aDmgbjdcWzfCmAna6j0RlYWKHAljGDuzVsnl_k2Vn4McNwF7Lh6H3Tp_gDogSlr6Ag
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODksImF1dGgiOiJVU0VSIn0.W8cPqtnC5KZux-bCPCE9XogUlVbmtH8Z-4skyZiFWQdOcklkeBj8Gt2bQGwUul_MKlWueKPhR46HilvmzKVl5g
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -716,7 +716,7 @@ Host: localhost:8080</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODc0NTc5NDF9.6FrQuEJnJNOfkxOyCSnpi0do1WIhZJ9K439PEbQg2iSm-9tbd1Bgi68fswHmdEfDfp_GpiuQQ8neltrGQ-pYzw; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODc3OTE1ODl9.9oSBCJ9TLYJtBVXbM2KL34kyClgmnI-TkHHHDl-Mn6UGhpMgsx-gVA3806Dq3CLKyQT4erxtH101NmZlhb6AQw; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 48
 
@@ -924,7 +924,7 @@ Host: localhost:8080
 
 {
   "phone_num" : "01011111111",
-  "code" : "8337"
+  "code" : "1844"
 }</code></pre>
 </div>
 </div>
@@ -990,7 +990,7 @@ Content-Length: 83
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users/update/nick-name HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDIsImF1dGgiOiJVU0VSIn0.VjfHQPA28mvka_RFe8OT8wEwy8KMFSDwMTlwuQdFRdz5oWlY2J5Zie_CMXVmiRv4Y0K0p4B8JsuTwCSvvXnuBQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODksImF1dGgiOiJVU0VSIn0.W8cPqtnC5KZux-bCPCE9XogUlVbmtH8Z-4skyZiFWQdOcklkeBj8Gt2bQGwUul_MKlWueKPhR46HilvmzKVl5g
 Accept: application/json
 Content-Length: 30
 Host: localhost:8080
@@ -1061,7 +1061,7 @@ Content-Length: 80
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users/update/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDQsImF1dGgiOiJVU0VSIn0.ubUJSdVTH4dymic6OnFPjK0lf1as1sn7JCublD4rovXflYSVXEY9T6yKcnGX5qLhMQLGxeHbGuryAm_UPoKLKw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1OTIsImF1dGgiOiJVU0VSIn0.eH3jUoOjojwErHK1DxD8tZpBzw22Qz9A7BKZQj-vPDw6UBeiU54Nsq_Mu-U-jBlsaeLiOJd5JITUcvvAqmkRxA
 Accept: application/json
 Content-Length: 32
 Host: localhost:8080
@@ -1131,7 +1131,7 @@ Content-Length: 83
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/users HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDEsImF1dGgiOiJVU0VSIn0.vNmQkVyTOaGCjrfWrxs6aDmgbjdcWzfCmAna6j0RlYWKHAljGDuzVsnl_k2Vn4McNwF7Lh6H3Tp_gDogSlr6Ag
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODksImF1dGgiOiJVU0VSIn0.W8cPqtnC5KZux-bCPCE9XogUlVbmtH8Z-4skyZiFWQdOcklkeBj8Gt2bQGwUul_MKlWueKPhR46HilvmzKVl5g
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1146,13 +1146,13 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 231
+Content-Length: 232
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "id" : 6595,
+    "id" : 22889,
     "email" : "test_jhouse_com",
     "nick_name" : "테스트유저1",
     "phone_num" : "01011111111",
@@ -1171,7 +1171,7 @@ Content-Length: 231
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/withdrawal HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODY4NTQ5NDEsImF1dGgiOiJVU0VSIn0.vNmQkVyTOaGCjrfWrxs6aDmgbjdcWzfCmAna6j0RlYWKHAljGDuzVsnl_k2Vn4McNwF7Lh6H3Tp_gDogSlr6Ag
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODcxODg1ODksImF1dGgiOiJVU0VSIn0.W8cPqtnC5KZux-bCPCE9XogUlVbmtH8Z-4skyZiFWQdOcklkeBj8Gt2bQGwUul_MKlWueKPhR46HilvmzKVl5g
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1202,7 +1202,7 @@ Content-Length: 48
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-13 17:32:16 +0900
+Last updated 2023-04-28 15:42:33 +0900
 </div>
 </div>
 </body>

--- a/src/test/kotlin/com/example/jhouse_server/domain/house/controller/HouseControllerTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/house/controller/HouseControllerTest.kt
@@ -1,0 +1,323 @@
+package com.example.jhouse_server.domain.house.controller
+
+import com.example.jhouse_server.domain.house.repository.HouseRepository
+import com.example.jhouse_server.domain.house.service.HouseService
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.domain.user.repository.UserRepository
+import com.example.jhouse_server.domain.user.service.UserService
+import com.example.jhouse_server.global.util.ApiControllerConfig
+import com.example.jhouse_server.global.util.MockEntity
+import com.example.jhouse_server.global.util.MockEntity.Companion.houseReqDto
+import com.example.jhouse_server.global.util.MockEntity.Companion.houseUpdateReqDto
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class HouseControllerTest @Autowired constructor(
+    private val houseService: HouseService,
+    private val userService: UserService,
+    private val userRepository: UserRepository
+): ApiControllerConfig("/api/v1/houses") {
+    private var accessToken: String? = null
+    private val userSignUpReqDto = MockEntity.testUserSignUpDto()
+    private val userSignInReqDto = MockEntity.testUserSignInDto()
+    private var user: User? = null
+    private var houseIds : MutableList<Long> = mutableListOf()
+
+    @BeforeEach
+    fun `로그인_더미데이터_생성`() {
+        // singUp
+        userService.signUp(userSignUpReqDto)
+        user = userRepository.findByEmail(userSignUpReqDto.email).get()
+        // signIn
+        val tokenDto = userService.signIn(userSignInReqDto)
+        accessToken = tokenDto.accessToken
+
+    }
+    @AfterEach
+    fun `더미데이터_초기화`() {
+        houseIds.clear()
+    }
+
+    @Test
+    @DisplayName("빈집 게시글 생성")
+    fun createHouse() {
+        // given
+        val req: String = objectMapper.writeValueAsString(MockEntity.houseReqDto())
+
+        // when
+        val resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post("$uri")
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .content(req)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+
+        // then
+        resultActions
+            .andExpect(status().isOk)
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                document(
+                    "save-house",
+                    requestFields(
+                        fieldWithPath("rentalType").description("매매 타입 ( SALE(매매), JEONSE(전세), MONTHLYRENT(월세) )은 필수값입니다. "),
+                        fieldWithPath("city").description("주소는 '시도'로 시작하되, 줄이지 않은 표현으로 작성해야 합니다. 예: 서울시 서대문구 거북골로 34"),
+                        fieldWithPath("zipCode").description("우편번호 ( string 형식입니다. )"),
+                        fieldWithPath("size").description("집 크기는 m^2 단위로 산정해서 작성해야 합니다. string 형식입니다."),
+                        fieldWithPath("purpose").description("매물 목적/용도 예: 거주 ( 방3, 화장실 2 )"),
+                        fieldWithPath("floorNum").description("매물이 위치한 층수 ( 단독주택인 경우, null 로 전달 시 서버에서 0으로 세팅 )"),
+                        fieldWithPath("sumFloor").description("매물이 위치한 건물의 총 층수 ( 단독주택인 경우, 단독주택이 갖는 층수를 작성할 것 )"),
+                        fieldWithPath("contact").description("연락 가능한 연락처를 01000000000 형식으로 작성"),
+                        fieldWithPath("createdDate").description("준공연도는 숫자만 입력해주세요. YYYY 형태로 서버에서 관리합니다."),
+                        fieldWithPath("price").description("매물가격은 만원 단위로 산정해서 작성해주세요. ( 월세의 경우, 보증금을 작성해주세요. )"),
+                        fieldWithPath("monthlyPrice").description("월세 가격은 만원 단위로 산정해서 소수점 포함으로 작성해주세요. Double 형식으로 관리합니다."),
+                        fieldWithPath("agentName").description("공인중개사명을 작성해주세요. ( 없는 경우, 서버에서 null로 관리합니다. )"),
+                        fieldWithPath("title").description("빈집 게시글의 제목을 입력해주세요."),
+                        fieldWithPath("code").description("빈집 게시글의 내용을 입력해주세요."),
+                        fieldWithPath("imageUrls").description("이미지 주소를 string 배열 형식으로 입력해주세요."),
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("결과 코드"),
+                        fieldWithPath("message").description("응답 메세지"),
+                        fieldWithPath("data").description("빈집 게시글 아이디"),
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("빈집 게시글 수정")
+    fun updateHouse() {
+        // given
+        val houseId = houseService.createHouse(MockEntity.houseReqDto(), user!!)
+        val req: String = objectMapper.writeValueAsString(houseUpdateReqDto())
+
+        // when
+        val resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .put("$uri/{houseId}", houseId)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .content(req)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+        // then
+        resultActions
+            .andExpect(status().isOk)
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                document(
+                    "update-house",
+                    pathParameters(
+                        parameterWithName("houseId").description("빈집 게시글 아이디"),
+                    ),
+                    requestFields(
+                        fieldWithPath("rentalType").description("매매 타입 ( SALE(매매), JEONSE(전세), MONTHLYRENT(월세) )은 필수값입니다. "),
+                        fieldWithPath("city").description("주소는 '시도'로 시작하되, 줄이지 않은 표현으로 작성해야 합니다. 예: 서울시 서대문구 거북골로 34"),
+                        fieldWithPath("zipCode").description("우편번호 ( string 형식입니다. )"),
+                        fieldWithPath("size").description("집 크기는 m^2 단위로 산정해서 작성해야 합니다. string 형식입니다."),
+                        fieldWithPath("purpose").description("매물 목적/용도 예: 거주 ( 방3, 화장실 2 )"),
+                        fieldWithPath("floorNum").description("매물이 위치한 층수 ( 단독주택인 경우, null 로 전달 시 서버에서 0으로 세팅 )"),
+                        fieldWithPath("sumFloor").description("매물이 위치한 건물의 총 층수 ( 단독주택인 경우, 단독주택이 갖는 층수를 작성할 것 )"),
+                        fieldWithPath("contact").description("연락 가능한 연락처를 01000000000 형식으로 작성"),
+                        fieldWithPath("createdDate").description("준공연도는 숫자만 입력해주세요. YYYY 형태로 서버에서 관리합니다."),
+                        fieldWithPath("price").description("매물가격은 만원 단위로 산정해서 작성해주세요. ( 월세의 경우, 보증금을 작성해주세요. )"),
+                        fieldWithPath("monthlyPrice").description("월세 가격은 만원 단위로 산정해서 소수점 포함으로 작성해주세요. Double 형식으로 관리합니다."),
+                        fieldWithPath("agentName").description("공인중개사명을 작성해주세요. ( 없는 경우, 서버에서 null로 관리합니다. )"),
+                        fieldWithPath("title").description("빈집 게시글의 제목을 입력해주세요."),
+                        fieldWithPath("code").description("빈집 게시글의 내용을 입력해주세요."),
+                        fieldWithPath("imageUrls").description("이미지 주소를 string 배열 형식으로 입력해주세요."),
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("결과 코드"),
+                        fieldWithPath("message").description("응답 메세지"),
+                        fieldWithPath("data").description("빈집 게시글 아이디"),
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("빈집 게시글 삭제")
+    fun deleteHouse() {
+        // given
+        val houseId = houseService.createHouse(houseReqDto(), user!!)
+
+        // when
+        val resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .delete("$uri/{houseId}", houseId)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+        // then
+        resultActions
+            .andExpect(status().isOk)
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                document("delete-house",
+                pathParameters(
+                    parameterWithName("houseId").description("빈집 게시글 아이디")
+                ),
+                    responseFields(
+                        fieldWithPath("code").description("결과 코드"),
+                        fieldWithPath("message").description("응답 메세지")
+                    )
+                )
+            )
+    }
+    @Test
+    @DisplayName("빈집 게시글 목록 조회")
+    fun getHouseAll() {
+        // given
+        // dummy for house
+        for(i in 0..10) {
+            houseIds.add(houseService.createHouse(houseReqDto(), user!!))
+            houseIds.add(houseService.createHouse(houseUpdateReqDto(), user!!))
+        }
+        // when
+        val resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .get("$uri?rentalType=SALE&city=서울&search=")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+
+        // then
+        resultActions
+            .andExpect(status().isOk)
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                document(
+                    "get-house-all",
+                    requestParameters(
+                        parameterWithName("rentalType").description("매매 타입"),
+                        parameterWithName("city").description("지역 필터링"),
+                        parameterWithName("search").description("검색어"),
+//                        parameterWithName("page").description("페이지 번호 (0부터 !)"),
+//                        parameterWithName("size").description("페이지 당 넘겨 받을 개수 ( 기본값 8개 )")
+                    ),
+                    responseFields(
+//                        fieldWithPath("code").description("결과 코드"),
+//                        fieldWithPath("message").description("응답 메세지"),
+                        beneathPath("data").withSubsectionId("data"),
+                        *pageResponseFieldSnippet()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("빈집 게시글 단일 조회")
+    fun getHouseOne() {
+        // given
+        // dummy for house
+        for(i in 0..10) {
+            houseIds.add(houseService.createHouse(houseReqDto(), user!!))
+            houseIds.add(houseService.createHouse(houseUpdateReqDto(), user!!))
+        }
+
+        val houseId = houseIds[0]
+
+        // when
+        val resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .get("$uri/{houseId}", houseId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+
+        // then
+        resultActions
+            .andExpect(status().isOk)
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                document(
+                    "get-house-one",
+                    pathParameters(
+                        parameterWithName("houseId").description("빈집 게시글 아이디")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("결과 코드"),
+                        fieldWithPath("message").description("응답 메세지"),
+                        fieldWithPath("data.houseId").description("빈집 게시글 아이디"),
+                        fieldWithPath("data.rentalType").description("매물 타입"),
+                        fieldWithPath("data.city").description("매물 위치"),
+                        fieldWithPath("data.zipcode").description("우편 주소"),
+                        fieldWithPath("data.purpose").description("매물 목적/용도"),
+                        fieldWithPath("data.floorNum").description("매물 층수"),
+                        fieldWithPath("data.sumFloor").description("매물이 위치한 건물 총 층수"),
+                        fieldWithPath("data.contact").description("연락 가능한 연락처"),
+                        fieldWithPath("data.createdDate").description("준공연도"),
+                        fieldWithPath("data.price").description("매물 가격"),
+                        fieldWithPath("data.monthlyPrice").description("월세 가격"),
+                        fieldWithPath("data.agentName").description("공인중개사명"),
+                        fieldWithPath("data.title").description("게시글 제목"),
+                        fieldWithPath("data.code").description("게시글 내용"),
+                        fieldWithPath("data.imageUrls").description("게시글 이미지 주소"),
+                        fieldWithPath("data.nickName").description("게시글 작성자"),
+                        fieldWithPath("data.createdAt").description("게시글 작성일자"),
+                        fieldWithPath("data.isCompleted").description("매물 거래 완료 여부")
+                    )
+                )
+            )
+    }
+
+    private fun pageResponseFieldSnippet(): Array<FieldDescriptor> {
+        return arrayOf(
+            fieldWithPath("content[].houseId").description("빈집 게시글 ID"),
+            fieldWithPath("content[].rentalType").description("매매 타입"),
+            fieldWithPath("content[].city").description("매물 위치"),
+            fieldWithPath("content[].price").description("매물 가격"),
+            fieldWithPath("content[].monthlyPrice").description("월세 가격"),
+            fieldWithPath("content[].nickName").description("게시글 작성자"),
+            fieldWithPath("content[].createdAt").description("게시글 작성날짜"),
+            fieldWithPath("content[].isCompleted").description("거래 완료 여부"),
+            fieldWithPath("pageable.sort.empty").description(""),
+            fieldWithPath("pageable.sort.unsorted").description(""),
+            fieldWithPath("pageable.sort.sorted").description(""),
+            fieldWithPath("pageable.offset").description(""),
+            fieldWithPath("pageable.pageNumber").description(""),
+            fieldWithPath("pageable.pageSize").description(""),
+            fieldWithPath("pageable.unpaged").description(""),
+            fieldWithPath("pageable.paged").description(""),
+            fieldWithPath("last").description(""),
+            fieldWithPath("totalPages").description(""),
+            fieldWithPath("totalElements").description(""),
+            fieldWithPath("size").description(""),
+            fieldWithPath("number").description(""),
+            fieldWithPath("sort.empty").description(""),
+            fieldWithPath("sort.unsorted").description(""),
+            fieldWithPath("sort.sorted").description(""),
+            fieldWithPath("first").description(""),
+            fieldWithPath("numberOfElements").description(""),
+            fieldWithPath("empty").description(""),
+        )
+    }
+}

--- a/src/test/kotlin/com/example/jhouse_server/global/util/MockEntity.kt
+++ b/src/test/kotlin/com/example/jhouse_server/global/util/MockEntity.kt
@@ -7,6 +7,8 @@ import com.example.jhouse_server.domain.board.entity.Board
 import com.example.jhouse_server.domain.board.entity.BoardCategory
 import com.example.jhouse_server.domain.comment.dto.CommentReqDto
 import com.example.jhouse_server.domain.comment.entity.Comment
+import com.example.jhouse_server.domain.house.dto.HouseReqDto
+import com.example.jhouse_server.domain.house.entity.RentalType
 import com.example.jhouse_server.domain.record.dto.RecordPageCondition
 import com.example.jhouse_server.domain.record.dto.RecordReqDto
 import com.example.jhouse_server.domain.record.dto.RecordUpdateDto
@@ -271,6 +273,41 @@ class MockEntity {
 
         fun recordCommentUpdateDto() = RecordCommentUpdateDto(
             content = "수정 내용"
+        )
+
+        fun houseReqDto() = HouseReqDto(
+            rentalType = RentalType.SALE,
+            city = "서울시 서대문구 남가좌동 거북골로 34",
+            zipCode = "12345",
+            size = "120909000",
+            purpose = "주거용 ( 방3, 화장실 2 )",
+            floorNum = 2,
+            sumFloor = 3,
+            contact = "070-1234-5678",
+            createdDate = "1990-09-09",
+            price = 12000,
+            monthlyPrice = 0.0,
+            agentName = "행복부동산",
+            title = "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
+            code = "<body> <div> <h2>행복부동산 최신 매물로</h2> </div> <div> <i>주거용 주택</i>을 소개합니다. </div> </body>",
+            imageUrls = mutableListOf("img-001", "img-002")
+            )
+        fun houseUpdateReqDto() = HouseReqDto(
+            rentalType = RentalType.JEONSE,
+            city = "서울시 서대문구 남가좌동 거북골로 90",
+            zipCode = "12345",
+            size = "120909000",
+            purpose = "게스트하우스 ( 방3, 화장실 2 )",
+            floorNum = 2,
+            sumFloor = 3,
+            contact = "070-1234-5678",
+            createdDate = "1990-09-09",
+            price = 12000,
+            monthlyPrice = 0.0,
+            agentName = "부자부동산",
+            title = "부자부동산에서 제공하는 서울시 빈집 매물입니다.",
+            code = "<body> <div> <h2>부자부동산 최신 매물로</h2> </div> <div> <i>게스트하우스용 주택</i>을 소개합니다. </div> </body>",
+            imageUrls = mutableListOf("img-001", "img-002")
         )
     }
 }


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

빈집 게시글 CRUD 기능 구현

## 작업 내용
- [x] 기능 정의서에 따른 ERD 설계 및 엔티티 정의 / 수정
- [x] 게시글 내용 글자수 10,000자 제한 유효성 검사 로직을 수행하기 위한 AOP 적용
- [x] 게시글 목록 조회 시, 필터링을 위한 동적 쿼리 작성
- [x] 컨트롤러 단위 테스트 코드 작성 및 문서 발행
- [x] prod 디비 서버에 테이블 생성

## 변경점

- 사용자 테이블에 빈집 게시글, 스크랩 연관관계 추가

이유 : 게시글 작성자와 스크랩의 주체를 파악하기 위함입니다.

- 게시글 정적 태그 사이에서 값 추출 함수 전역으로 변경

이유 : 커뮤니티 게시판에서만 사용하던 지역 함수를 빈집 게시글에서도 사용하기 위해 전역함수로 변경하였습니다.

- 유효성검사 AOP 등록

이유 : 컨트롤러에 요청이 바인딩되기 이전에 유효성 검사를 실행함으로써 쓰레드 자원 소모를 막습니다. 

## To-Do

서비스 계층 테스트 코드 작성

## CheckList

- [x] CI를 통과했나요?
- [x] 리뷰어를 등록했나요?
- [x] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?