### PR TITLE
[Feat/auth] 공인중개사 회원가입 추가

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,6 +1,6 @@
 == User API
 
-=== 1. 회원가입
+=== 1-1. 회원가입
 ===== Request
 include::{snippets}/sign-up/http-request.adoc[]
 ===== Response - Success
@@ -11,6 +11,13 @@ include::{snippets}/password-validation/http-response.adoc[]
 include::{snippets}/nickname-validation/http-response.adoc[]
 include::{snippets}/phonenum-validation/http-response.adoc[]
 
+=== 1-2. 공인중개사 회원가입
+===== Request
+include::{snippets}/agent-sign-up/http-request.adoc[]
+===== Request Field
+include::{snippets}/agent-sign-up/request-fields.adoc[]
+===== Response
+include::{snippets}/agent-sign-up/http-response.adoc[]
 
 === 2. 로그인
 ===== Request

--- a/src/main/kotlin/com/example/jhouse_server/domain/record/service/RecordServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/record/service/RecordServiceImpl.kt
@@ -204,7 +204,7 @@ class RecordServiceImpl(
 
     private fun applyForReview(record: Record, user: User) {
         recordReviewApplyRepository.save(RecordReviewApply(RecordReviewApplyStatus.MINE, record, user))
-        val reviewers = userRepository.findAllByUserType(user.id, user.userType!!)
+        val reviewers = userRepository.findAllByUserType(user.id, user.userType)
         reviewers.forEach {
             val recordReviewApply = RecordReviewApply(RecordReviewApplyStatus.WAIT, record, it)
             recordReviewApplyRepository.save(recordReviewApply)

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/controller/agent/AgentController.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/controller/agent/AgentController.kt
@@ -1,0 +1,25 @@
+package com.example.jhouse_server.domain.user.controller.agent
+
+import com.example.jhouse_server.domain.user.AgentSignUpReqDto
+import com.example.jhouse_server.domain.user.service.agent.AgentService
+import com.example.jhouse_server.global.response.ApplicationResponse
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/agents")
+class AgentController(
+    val agentService: AgentService
+) {
+
+    @PostMapping("/sign-up")
+    fun singUp(
+        @Validated @RequestBody agentSignUpReqDto: AgentSignUpReqDto
+    ): ApplicationResponse<Nothing> {
+        agentService.signUp(agentSignUpReqDto)
+        return ApplicationResponse.ok()
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/dto/UserDto.kt
@@ -4,11 +4,12 @@ import com.example.jhouse_server.domain.user.entity.Age
 import com.example.jhouse_server.domain.user.entity.Authority
 import com.example.jhouse_server.domain.user.entity.User
 import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.constraints.Email
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
 
 data class UserSignUpReqDto(
-        @field:Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}\$", message = "이메일 형식에 맞지 않습니다.")
+        @field:Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}\$", message = "아이디 형식에 맞지 않습니다.")
         val email: String,
         @field:Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#\$%^&*.?])[A-Za-z0-9!@#\$%^&*.?]{8,16}\$", message = "비밀번호 형식에 맞지 않습니다.")
         val password: String,
@@ -18,6 +19,34 @@ data class UserSignUpReqDto(
         @JsonProperty("phone_num") val phoneNum: String,
         @NotNull val age: String,
         @NotNull @JsonProperty("join_paths") val joinPaths: MutableList<String>
+)
+
+data class AgentSignUpReqDto(
+        @field:Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z_0-9]{4,20}\$", message = "아이디 형식에 맞지 않습니다.")
+        val email: String,
+        @field:Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#\$%^&*.?])[A-Za-z0-9!@#\$%^&*.?]{8,16}\$", message = "비밀번호 형식에 맞지 않습니다.")
+        val password: String,
+        @field:Pattern(regexp = "^(?=.*[a-zA-Z0-9가-힣])[A-Za-z0-9가-힣]{1,20}\$", message = "닉네임 형식에 맞지 않습니다.")
+        @JsonProperty("nick_name") val nickName: String,
+        @field:Pattern(regexp = "^01(?:0|1|[6-9])[0-9]{7,8}", message = "전화번호 형식에 맞지 않습니다.")
+        @JsonProperty("phone_num") val phoneNum: String,
+        @NotNull val age: String,
+        @NotNull @JsonProperty("join_paths") val joinPaths: MutableList<String>,
+
+        @field:Pattern(regexp = "^[0-9,-]{14}\$", message = "공인중개사 등록번호 형식에 맞지 않습니다.")
+        @JsonProperty("agent_code") val agentCode: String,
+        @field:Pattern(regexp = "^[0-9,-]{10}\$", message = "사업자 등록번호 형식에 맞지 않습니다.")
+        @JsonProperty("business_code") val businessCode: String,
+        @NotNull @JsonProperty("company_name") val companyName: String,
+        @NotNull @JsonProperty("agent_name") val agentName: String,
+        @field:Pattern(regexp = "^0(?:2|3[1-3]|4[1-3]|5[1-5]|6[1-4])[0-9]{7,8}", message = "사무소 번호 형식에 맞지 않습니다.")
+        @NotNull @JsonProperty("company_phone_num") val companyPhoneNum: String,
+        @JsonProperty("assistant_name") val assistantName: String?,
+        @NotNull @JsonProperty("company_address") val companyAddress: String,
+        @NotNull @JsonProperty("company_address_detail") val companyAddressDetail: String,
+        @field:Email(message = "이메일 형식에 맞지 않습니다.") @NotNull
+        @JsonProperty("company_email") val companyEmail: String,
+        @NotNull val estate: String,
 )
 
 data class UserSignInReqDto(

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
@@ -13,6 +13,7 @@ import com.example.jhouse_server.global.entity.BaseEntity
 import javax.persistence.*
 
 @Entity
+@DiscriminatorValue("U")
 class User(
     @Convert(converter = CryptoConverter::class)
     var email: String,
@@ -33,6 +34,10 @@ class User(
     @Convert(converter = CryptoConverter::class)
     @Enumerated(EnumType.STRING)
     var age: Age,
+
+    @Convert(converter = CryptoConverter::class)
+    @Enumerated(EnumType.STRING)
+    var userType: UserType,
 
     @OneToMany(mappedBy = "user")
     val joinPaths: MutableList<UserJoinPath> = mutableListOf(),
@@ -65,8 +70,6 @@ class User(
     @GeneratedValue(strategy = GenerationType.AUTO)
     val id : Long = 0L,
 ): BaseEntity() {
-    @Enumerated(EnumType.STRING)
-    var userType: UserType? = null
 
     fun update(phoneNum: String) {
         this.phoneNum = phoneNum

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/UserType.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/UserType.kt
@@ -2,5 +2,7 @@ package com.example.jhouse_server.domain.user.entity
 
 enum class UserType(val authority: Authority) {
     WEB(Authority.ADMIN),
-    SERVER(Authority.ADMIN);
+    SERVER(Authority.ADMIN),
+    NONE(Authority.USER),
+    AGENT(Authority.USER);
 }

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/agent/Agent.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/agent/Agent.kt
@@ -1,0 +1,45 @@
+package com.example.jhouse_server.domain.user.entity.agent
+
+import com.example.jhouse_server.domain.user.entity.*
+import javax.persistence.*
+
+@Entity
+@DiscriminatorValue("A")
+class Agent(
+    email: String, password: String, nickName: String,
+    phoneNum: String, authority: Authority, age: Age, userType: UserType,
+
+    @Convert(converter = CryptoConverter::class)
+    var agentCode: String,
+
+    @Convert(converter = CryptoConverter::class)
+    var businessCode: String,
+
+    @Convert(converter = CryptoConverter::class)
+    var companyName: String,
+
+    @Convert(converter = CryptoConverter::class)
+    var agentName: String,
+
+    @Convert(converter = CryptoConverter::class)
+    var companyPhoneNum: String,
+
+    var assistantName: String?,
+
+    @Convert(converter = CryptoConverter::class)
+    var companyAddress: String,
+
+    @Convert(converter = CryptoConverter::class)
+    var companyEmail: String,
+
+    @Enumerated(EnumType.STRING)
+    var estate: Estate,
+
+    @Enumerated(EnumType.STRING)
+    var status: AgentStatus
+): User(email, password, nickName, phoneNum, authority, age, userType) {
+
+    fun updateStatus(status: AgentStatus) {
+        this.status = status
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/agent/AgentStatus.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/agent/AgentStatus.kt
@@ -1,0 +1,5 @@
+package com.example.jhouse_server.domain.user.entity.agent
+
+enum class AgentStatus {
+    WAIT, APPROVE
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/agent/Estate.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/agent/Estate.kt
@@ -1,0 +1,21 @@
+package com.example.jhouse_server.domain.user.entity.agent
+
+import com.example.jhouse_server.global.exception.ApplicationException
+import com.example.jhouse_server.global.exception.ErrorCode
+
+enum class Estate(val value: String) {
+    APARTMENT("아파트"),
+    HOUSE("주택"),
+    FARM("농가");
+
+    companion object {
+        fun getEstate(value: String): Estate {
+            for(estate in Estate.values()) {
+                if(estate.value == value) {
+                    return estate
+                }
+            }
+            throw ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/service/agent/AgentService.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/service/agent/AgentService.kt
@@ -1,0 +1,10 @@
+package com.example.jhouse_server.domain.user.service.agent
+
+import com.example.jhouse_server.domain.user.AgentSignUpReqDto
+import com.example.jhouse_server.domain.user.entity.User
+
+interface AgentService {
+    fun signUp(agentSignUpReqDto: AgentSignUpReqDto)
+
+    fun approveStatus(user: User)
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/service/agent/AgentServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/service/agent/AgentServiceImpl.kt
@@ -1,0 +1,48 @@
+package com.example.jhouse_server.domain.user.service.agent
+
+import com.example.jhouse_server.domain.user.AgentSignUpReqDto
+import com.example.jhouse_server.domain.user.entity.*
+import com.example.jhouse_server.domain.user.entity.agent.Agent
+import com.example.jhouse_server.domain.user.entity.agent.AgentStatus
+import com.example.jhouse_server.domain.user.entity.agent.Estate
+import com.example.jhouse_server.domain.user.repository.UserRepository
+import com.example.jhouse_server.domain.user.service.common.UserServiceCommonMethod
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AgentServiceImpl(
+    val userRepository: UserRepository,
+    val userServiceCommonMethod: UserServiceCommonMethod
+): AgentService {
+
+    @Transactional
+    override fun signUp(agentSignUpReqDto: AgentSignUpReqDto) {
+        userServiceCommonMethod.validateDuplicate(agentSignUpReqDto.email, agentSignUpReqDto.nickName, agentSignUpReqDto.companyPhoneNum)
+
+        val age: Age = Age.getAge(agentSignUpReqDto.age)!!
+        val joinPaths: MutableList<JoinPath> = mutableListOf()
+        for(joinPath in agentSignUpReqDto.joinPaths) {
+            joinPaths.add(JoinPath.getJoinPath(joinPath)!!)
+        }
+        val address = agentSignUpReqDto.companyAddress.plus(" ").plus(agentSignUpReqDto.companyAddressDetail)
+
+        val agent = Agent(agentSignUpReqDto.email, userServiceCommonMethod.encodePassword(agentSignUpReqDto.password),
+            agentSignUpReqDto.nickName, agentSignUpReqDto.phoneNum, Authority.USER, age, UserType.AGENT,
+            agentSignUpReqDto.agentCode, agentSignUpReqDto.businessCode, agentSignUpReqDto.companyName,
+            agentSignUpReqDto.agentName, agentSignUpReqDto.companyPhoneNum, agentSignUpReqDto.assistantName,
+            address, agentSignUpReqDto.companyEmail, Estate.getEstate(agentSignUpReqDto.estate), AgentStatus.WAIT)
+        userRepository.save(agent)
+
+        for(joinPath in joinPaths) {
+            userServiceCommonMethod.saveUserJoinPath(joinPath, agent)
+        }
+    }
+
+    @Transactional
+    override fun approveStatus(user: User) {
+        val agent = user as Agent
+        agent.updateStatus(AgentStatus.APPROVE)
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/service/common/UserServiceCommonMethod.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/service/common/UserServiceCommonMethod.kt
@@ -1,0 +1,46 @@
+package com.example.jhouse_server.domain.user.service.common
+
+import com.example.jhouse_server.domain.user.UserSignUpReqDto
+import com.example.jhouse_server.domain.user.entity.JoinPath
+import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.domain.user.entity.UserJoinPath
+import com.example.jhouse_server.domain.user.repository.UserJoinPathRepository
+import com.example.jhouse_server.domain.user.repository.UserRepository
+import com.example.jhouse_server.global.exception.ApplicationException
+import com.example.jhouse_server.global.exception.ErrorCode
+import org.springframework.stereotype.Component
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+@Component
+class UserServiceCommonMethod(
+    val userRepository: UserRepository,
+    val userJoinPathRepository: UserJoinPathRepository
+) {
+
+    fun encodePassword(password: String): String {
+        val messageDigest = MessageDigest.getInstance("SHA-512")
+        messageDigest.reset()
+        messageDigest.update(password.toByteArray(StandardCharsets.UTF_8))
+
+        return String.format("%0128x", BigInteger(1, messageDigest.digest()))
+    }
+
+    fun saveUserJoinPath(joinPath: JoinPath, user: User) {
+        val userJoinPath = UserJoinPath(joinPath, user)
+        userJoinPathRepository.save(userJoinPath)
+    }
+
+    fun validateDuplicate(email: String, nickName: String, phoneNum: String) {
+        if(userRepository.existsByEmail(email)) {
+            throw ApplicationException(ErrorCode.EXIST_EMAIL)
+        }
+        if(userRepository.existsByNickName(nickName)) {
+            throw ApplicationException(ErrorCode.EXIST_NICK_NAME)
+        }
+        if(userRepository.existsByPhoneNum(phoneNum)) {
+            throw ApplicationException(ErrorCode.EXIST_PHONE_NUM)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/jhouse_server/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/exception/ErrorCode.kt
@@ -29,6 +29,7 @@ enum class ErrorCode(
     DONT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "U0002", "비밀번호가 일치하지 않습니다."),
     EXIST_NICK_NAME(HttpStatus.BAD_REQUEST, "U0005", "이미 존재하는 닉네임입니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "U0006", "비밀번호가 같습니다."),
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "U0007", "이미 가입된 아이디입니다."),
 
     // Post
     ALREADY_LOVE(HttpStatus.BAD_REQUEST, "P0000", "이미 좋아요를 한 게시글입니다."),

--- a/src/main/kotlin/com/example/jhouse_server/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/jwt/TokenProvider.kt
@@ -2,6 +2,7 @@ package com.example.jhouse_server.global.jwt
 
 import com.example.jhouse_server.domain.user.entity.Authority
 import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.domain.user.entity.UserType
 import com.example.jhouse_server.global.exception.ApplicationException
 import com.example.jhouse_server.global.exception.ErrorCode.*
 import io.jsonwebtoken.*
@@ -21,6 +22,8 @@ class TokenProvider {
 
     private val AUTHORITIES_KEY: String = "auth"
 
+    private val USER_TYPE_KEY: String = "type"
+
     private val BEARER_PREFIX: String = "Bearer "
 
     private val key: Key
@@ -37,6 +40,7 @@ class TokenProvider {
                 .setSubject(user.email)
                 .setExpiration(Date(now.time + ACCESS_TOKEN_EXPIRE_TIME))
                 .claim(AUTHORITIES_KEY, user.authority)
+                .claim(USER_TYPE_KEY, user.userType)
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact()
 
@@ -93,5 +97,11 @@ class TokenProvider {
         val claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
 
         return Authority.valueOf(claims[AUTHORITIES_KEY].toString())
+    }
+
+    fun getType(token: String): UserType {
+        val claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
+
+        return UserType.valueOf(claims[USER_TYPE_KEY].toString())
     }
 }

--- a/src/main/kotlin/com/example/jhouse_server/global/resolver/AuthUserResolver.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/resolver/AuthUserResolver.kt
@@ -1,8 +1,14 @@
 package com.example.jhouse_server.global.resolver
 
 import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.domain.user.entity.UserType
+import com.example.jhouse_server.domain.user.entity.agent.Agent
+import com.example.jhouse_server.domain.user.entity.agent.AgentStatus
 import com.example.jhouse_server.domain.user.repository.UserRepository
 import com.example.jhouse_server.global.annotation.AuthUser
+import com.example.jhouse_server.global.exception.ApplicationException
+import com.example.jhouse_server.global.exception.ErrorCode
+import com.example.jhouse_server.global.exception.ErrorCode.UNAUTHORIZED_EXCEPTION
 import com.example.jhouse_server.global.jwt.TokenProvider
 import org.springframework.core.MethodParameter
 import org.springframework.stereotype.Component
@@ -34,7 +40,15 @@ class AuthUserResolver (
         tokenProvider.validateToken(jwt, true)
 
         val email: String = tokenProvider.getSubject(jwt)
+        val user = userRepository.findByEmail(email).orElseThrow()
 
-        return userRepository.findByEmail(email).orElseThrow()
+        if(tokenProvider.getType(jwt) == UserType.AGENT) {
+            val agent = user as Agent
+            if (agent.status == AgentStatus.WAIT) {
+                throw ApplicationException(UNAUTHORIZED_EXCEPTION)
+            }
+        }
+
+        return user
     }
 }

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -444,7 +444,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h2 id="_user_api">User API</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_1_회원가입">1. 회원가입</h3>
+<h3 id="_1_1_회원가입">1-1. 회원가입</h3>
 <div class="sect4">
 <h5 id="_request">Request</h5>
 <div class="listingblock">
@@ -549,9 +549,160 @@ Content-Length: 83
 </div>
 </div>
 <div class="sect2">
-<h3 id="_2_로그인">2. 로그인</h3>
+<h3 id="_1_2_공인중개사_회원가입">1-2. 공인중개사 회원가입</h3>
 <div class="sect4">
 <h5 id="_request_2">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/agents/sign-up HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Content-Length: 564
+Host: localhost:8080
+
+{
+  "email" : "agent_jhouse_com",
+  "password" : "abcdefG123!",
+  "nick_name" : "공인중개사",
+  "phone_num" : "01044444444",
+  "age" : "20대 미만",
+  "join_paths" : [ "네이버 카페", "인스타그램" ],
+  "agent_code" : "123-456-789-01",
+  "business_code" : "12345-6789",
+  "company_name" : "주말내집",
+  "agent_name" : "오도리",
+  "company_phone_num" : "0212345678",
+  "assistant_name" : null,
+  "company_address" : "서울특별시",
+  "company_address_detail" : "강남구",
+  "company_email" : "agent@duaily.net",
+  "estate" : "아파트"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_request_field">Request Field</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nick_name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phone_num</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전화번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">연령대</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>join_paths</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">가입 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>agent_code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사 등록번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>business_code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사업자 등록번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>company_name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사 사무소 상호명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>agent_name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대표자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>company_phone_num</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사 사무소 대표 전화번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>assistant_name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중개 보조원명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>company_address</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사 사무소 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>company_address_detail</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사 사무소 상세 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>company_email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공인중개사 이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>estate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주거래 매물</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_response">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 48
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_2_로그인">2. 로그인</h3>
+<div class="sect4">
+<h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/sign-in HTTP/1.1
@@ -575,15 +726,15 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODgxMzEzNjJ9.hMYghXdlsKLsZD9eQTbD3QRUX2V8bvTnqiM7KQTAq9h0CsNKYd6AD3Y1pacxpybZUockJwyrakyJbdCOa3Yx6w; Path=/; Domain=localhost; Max-Age=604800; Expires=Fri, 30 Jun 2023 13:22:42 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODg0NzczNzB9.i30RHy3GsCUdSa5VRU57fMUqrwtAyaKR2Tb58oJSbApJEWfTKouALLGQKRnTd4wTGyEIBHMqAdRbATBhFrL5vw; Path=/; Domain=localhost; Max-Age=604800; Expires=Tue, 4 Jul 2023 13:29:30 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
-Content-Length: 280
+Content-Length: 299
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw"
+    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.-wL4Pk3I-aDCxu6HJ1_GWp-4h4HFYppFncZ8R6kUSey5gLGeF0rdSQ_csM-iDWWRLoQuTeXjXhs2cAg6PNo3Xw"
   }
 }</code></pre>
 </div>
@@ -656,18 +807,18 @@ Content-Length: 83
 <div class="sect2">
 <h3 id="_3_토큰_재발급">3. 토큰 재발급</h3>
 <div class="sect4">
-<h5 id="_request_3">Request</h5>
+<h5 id="_request_4">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/reissue HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 215
+Content-Length: 234
 Host: localhost:8080
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.NcQgnscOokil5JQybZL8a3J1KdawSQlVPI5aQ30_XeVPOUaLIa8-2HnZksbzMREv_yqMGtp6s_SUs2G_nn4pZw
 
 {
-  "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw"
+  "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.NcQgnscOokil5JQybZL8a3J1KdawSQlVPI5aQ30_XeVPOUaLIa8-2HnZksbzMREv_yqMGtp6s_SUs2G_nn4pZw"
 }</code></pre>
 </div>
 </div>
@@ -680,15 +831,15 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleH
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODgxMzEzNjJ9.hMYghXdlsKLsZD9eQTbD3QRUX2V8bvTnqiM7KQTAq9h0CsNKYd6AD3Y1pacxpybZUockJwyrakyJbdCOa3Yx6w; Path=/; Domain=localhost; Max-Age=604800; Expires=Fri, 30 Jun 2023 13:22:42 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODg0NzczNzF9.mqX6Z6tW9onH4gvY-lzaWV3CaaorURbDzRxoo-PKmBhIXWsTNvT3iWYEhv9pP1wU2Gv1nXJ04QIICIT1FXfM-Q; Path=/; Domain=localhost; Max-Age=604800; Expires=Tue, 4 Jul 2023 13:29:31 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
-Content-Length: 280
+Content-Length: 299
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw"
+    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.NcQgnscOokil5JQybZL8a3J1KdawSQlVPI5aQ30_XeVPOUaLIa8-2HnZksbzMREv_yqMGtp6s_SUs2G_nn4pZw"
   }
 }</code></pre>
 </div>
@@ -698,25 +849,25 @@ Content-Length: 280
 <div class="sect2">
 <h3 id="_4_로그아웃">4. 로그아웃</h3>
 <div class="sect4">
-<h5 id="_request_4">Request</h5>
+<h5 id="_request_5">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/logout HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.-wL4Pk3I-aDCxu6HJ1_GWp-4h4HFYppFncZ8R6kUSey5gLGeF0rdSQ_csM-iDWWRLoQuTeXjXhs2cAg6PNo3Xw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response">Response</h5>
+<h5 id="_response_2">Response</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODgxMzEzNjJ9.hMYghXdlsKLsZD9eQTbD3QRUX2V8bvTnqiM7KQTAq9h0CsNKYd6AD3Y1pacxpybZUockJwyrakyJbdCOa3Yx6w; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2ODg0NzczNzB9.i30RHy3GsCUdSa5VRU57fMUqrwtAyaKR2Tb58oJSbApJEWfTKouALLGQKRnTd4wTGyEIBHMqAdRbATBhFrL5vw; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 48
 
@@ -731,7 +882,7 @@ Content-Length: 48
 <div class="sect2">
 <h3 id="_5_이메일_중복_검사">5. 이메일 중복 검사</h3>
 <div class="sect4">
-<h5 id="_request_5">Request</h5>
+<h5 id="_request_6">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/check/email HTTP/1.1
@@ -787,7 +938,7 @@ Content-Length: 80
 <div class="sect2">
 <h3 id="_6_닉네임_중복_검사">6. 닉네임 중복 검사</h3>
 <div class="sect4">
-<h5 id="_request_6">Request</h5>
+<h5 id="_request_7">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/check/nick-name HTTP/1.1
@@ -843,7 +994,7 @@ Content-Length: 80
 <div class="sect2">
 <h3 id="_7_인증문자_전송">7. 인증문자 전송</h3>
 <div class="sect4">
-<h5 id="_request_7">Request</h5>
+<h5 id="_request_8">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/send/sms HTTP/1.1
@@ -913,7 +1064,7 @@ Content-Length: 79
 <div class="sect2">
 <h3 id="_8_인증문자_검증">8. 인증문자 검증</h3>
 <div class="sect4">
-<h5 id="_request_8">Request</h5>
+<h5 id="_request_9">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/check/sms HTTP/1.1
@@ -924,7 +1075,7 @@ Host: localhost:8080
 
 {
   "phone_num" : "01011111111",
-  "code" : "2523"
+  "code" : "2628"
 }</code></pre>
 </div>
 </div>
@@ -985,12 +1136,12 @@ Content-Length: 83
 <div class="sect2">
 <h3 id="_9_닉네임_수정">9. 닉네임 수정</h3>
 <div class="sect4">
-<h5 id="_request_9">Request</h5>
+<h5 id="_request_10">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users/update/nick-name HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.NcQgnscOokil5JQybZL8a3J1KdawSQlVPI5aQ30_XeVPOUaLIa8-2HnZksbzMREv_yqMGtp6s_SUs2G_nn4pZw
 Accept: application/json
 Content-Length: 30
 Host: localhost:8080
@@ -1056,12 +1207,12 @@ Content-Length: 80
 <div class="sect2">
 <h3 id="_10_비밀번호_수정">10. 비밀번호 수정</h3>
 <div class="sect4">
-<h5 id="_request_10">Request</h5>
+<h5 id="_request_11">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users/update/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjMsImF1dGgiOiJVU0VSIn0.NcCIfHpsDOaqb7r7Foz-lR6ge9sX3rav6_UK79AUeokod13YErg7ltbmN_Oz5w6XOkELg5TPRjh2BPy9mZI0Vg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.A1mtlj4J7ysOOUz73dTySM0jhEblcJv5SDlWx72e68dxdfh_PSfDSunfFlUzGD7I7xSpFC0yQ1Sf6X0VXkU8tA
 Accept: application/json
 Content-Length: 32
 Host: localhost:8080
@@ -1127,18 +1278,18 @@ Content-Length: 83
 <div class="sect2">
 <h3 id="_11_유저_정보_조회">11. 유저 정보 조회</h3>
 <div class="sect4">
-<h5 id="_request_11">Request</h5>
+<h5 id="_request_12">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/users HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.-wL4Pk3I-aDCxu6HJ1_GWp-4h4HFYppFncZ8R6kUSey5gLGeF0rdSQ_csM-iDWWRLoQuTeXjXhs2cAg6PNo3Xw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_2">Response</h5>
+<h5 id="_response_3">Response</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
@@ -1146,13 +1297,13 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 232
+Content-Length: 230
 
 {
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "id" : 30824,
+    "id" : 733,
     "email" : "test_jhouse_com",
     "nick_name" : "테스트유저1",
     "phone_num" : "01011111111",
@@ -1167,18 +1318,18 @@ Content-Length: 232
 <div class="sect2">
 <h3 id="_12_유저_탈퇴">12. 유저 탈퇴</h3>
 <div class="sect4">
-<h5 id="_request_12">Request</h5>
+<h5 id="_request_13">Request</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/withdrawal HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc1MjgzNjIsImF1dGgiOiJVU0VSIn0.W3NEe4OsuPiv5aspYqoixz8YvsPuvlKEv6ZYOiX8Zr9hF9_xebEeBDqGVrxcYkem1BHTXMJd_FDraeOlwlzLNw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2ODc4NzQzNzAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.-wL4Pk3I-aDCxu6HJ1_GWp-4h4HFYppFncZ8R6kUSey5gLGeF0rdSQ_csM-iDWWRLoQuTeXjXhs2cAg6PNo3Xw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_3">Response</h5>
+<h5 id="_response_4">Response</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
@@ -1202,7 +1353,7 @@ Content-Length: 48
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-28 15:42:33 +0900
+Last updated 2023-06-27 22:29:11 +0900
 </div>
 </div>
 </body>

--- a/src/test/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImplTest.kt
@@ -31,8 +31,8 @@ internal class BoardServiceImplTest @Autowired constructor(
     val userService: UserService,
     val userRepository: UserRepository,
 ) {
-    private val userSignUpReqDto = MockEntity.testUserSignUpDto()
-    private val testSignUpReqDto = MockEntity.testUser1()
+    private val userSignUpReqDto = MockEntity.testUserSignUpDto2()
+    private val testSignUpReqDto = MockEntity.testUserSignUpDto()
     @BeforeEach
     fun `회원가입`() {
         // default user

--- a/src/test/kotlin/com/example/jhouse_server/domain/comment/service/CommentServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/comment/service/CommentServiceImplTest.kt
@@ -30,8 +30,8 @@ internal class CommentServiceImplTest @Autowired constructor(
     val userService: UserService,
     val userRepository: UserRepository
 ) {
-    private val userSignUpReqDto = MockEntity.testUserSignUpDto()
-    private val testSignUpReqDto = MockEntity.testUser1()
+    private val userSignUpReqDto = MockEntity.testUserSignUpDto2()
+    private val testSignUpReqDto = MockEntity.testUserSignUpDto()
     @BeforeEach
     fun `회원가입`() {
         // default user

--- a/src/test/kotlin/com/example/jhouse_server/domain/love/service/LoveServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/love/service/LoveServiceImplTest.kt
@@ -28,8 +28,8 @@ internal class LoveServiceImplTest @Autowired constructor(
     val userService: UserService,
     val userRepository: UserRepository
 ) {
-    private val userSignUpReqDto = MockEntity.testUserSignUpDto()
-    private val testSignUpReqDto = MockEntity.testUser1()
+    private val userSignUpReqDto = MockEntity.testUserSignUpDto2()
+    private val testSignUpReqDto = MockEntity.testUserSignUpDto()
     @BeforeEach
     fun `회원가입`() {
         // default user

--- a/src/test/kotlin/com/example/jhouse_server/domain/user/controller/AgentControllerTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/user/controller/AgentControllerTest.kt
@@ -1,4 +1,70 @@
 package com.example.jhouse_server.domain.user.controller
 
-class AgentControllerTest {
+import com.example.jhouse_server.global.util.ApiControllerConfig
+import com.example.jhouse_server.global.util.MockEntity
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class AgentControllerTest: ApiControllerConfig("/api/v1/agents") {
+
+    private val agentSignUpDto = MockEntity.testAgentSignUpDto()
+
+    @Test
+    @DisplayName("공인중개사 회원가입 테스트")
+    fun signUp() {
+        //given
+        val content: String = objectMapper.writeValueAsString(agentSignUpDto)
+
+        //when
+        val resultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post("$uri/sign-up")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        )
+
+        //then
+        resultActions
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "agent-sign-up",
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("email").description("이메일"),
+                        PayloadDocumentation.fieldWithPath("password").description("비밀번호"),
+                        PayloadDocumentation.fieldWithPath("nick_name").description("닉네임"),
+                        PayloadDocumentation.fieldWithPath("phone_num").description("전화번호"),
+                        PayloadDocumentation.fieldWithPath("age").description("연령대"),
+                        PayloadDocumentation.fieldWithPath("join_paths").description("가입 경로"),
+                        PayloadDocumentation.fieldWithPath("agent_code").description("공인중개사 등록번호"),
+                        PayloadDocumentation.fieldWithPath("business_code").description("사업자 등록번호"),
+                        PayloadDocumentation.fieldWithPath("company_name").description("공인중개사 사무소 상호명"),
+                        PayloadDocumentation.fieldWithPath("agent_name").description("대표자 이름"),
+                        PayloadDocumentation.fieldWithPath("company_phone_num").description("공인중개사 사무소 대표 전화번호"),
+                        PayloadDocumentation.fieldWithPath("assistant_name").description("중개 보조원명"),
+                        PayloadDocumentation.fieldWithPath("company_address").description("공인중개사 사무소 주소"),
+                        PayloadDocumentation.fieldWithPath("company_address_detail").description("공인중개사 사무소 상세 주소"),
+                        PayloadDocumentation.fieldWithPath("company_email").description("공인중개사 이메일"),
+                        PayloadDocumentation.fieldWithPath("estate").description("주거래 매물")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("code").description("결과 코드"),
+                        PayloadDocumentation.fieldWithPath("message").description("응답 메세지")
+                    )
+                )
+            )
+    }
 }

--- a/src/test/kotlin/com/example/jhouse_server/domain/user/controller/AgentControllerTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/user/controller/AgentControllerTest.kt
@@ -1,0 +1,4 @@
+package com.example.jhouse_server.domain.user.controller
+
+class AgentControllerTest {
+}

--- a/src/test/kotlin/com/example/jhouse_server/domain/user/service/AgentServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/user/service/AgentServiceImplTest.kt
@@ -1,0 +1,4 @@
+package com.example.jhouse_server.domain.user.service
+
+class AgentServiceImplTest {
+}

--- a/src/test/kotlin/com/example/jhouse_server/domain/user/service/AgentServiceImplTest.kt
+++ b/src/test/kotlin/com/example/jhouse_server/domain/user/service/AgentServiceImplTest.kt
@@ -1,4 +1,46 @@
 package com.example.jhouse_server.domain.user.service
 
-class AgentServiceImplTest {
+import com.example.jhouse_server.domain.user.entity.agent.Agent
+import com.example.jhouse_server.domain.user.entity.agent.Estate
+import com.example.jhouse_server.domain.user.repository.UserRepository
+import com.example.jhouse_server.domain.user.service.agent.AgentService
+import com.example.jhouse_server.global.util.MockEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+class AgentServiceImplTest @Autowired constructor(
+    val agentService: AgentService,
+    val userRepository: UserRepository
+) {
+
+    private val agentSignUpDto = MockEntity.testAgentSignUpDto()
+
+    @Test
+    @DisplayName("공인중개사 테스트")
+    fun signUpTest() {
+        //given
+
+        //when
+        agentService.signUp(agentSignUpDto)
+
+        //then
+        val agent = userRepository.findByEmail(agentSignUpDto.email).get() as Agent
+        assertThat(agent.email).isEqualTo(agentSignUpDto.email)
+        assertThat(agent.nickName).isEqualTo(agentSignUpDto.nickName)
+        assertThat(agent.phoneNum).isEqualTo(agentSignUpDto.phoneNum)
+        assertThat(agent.agentCode).isEqualTo(agentSignUpDto.agentCode)
+        assertThat(agent.businessCode).isEqualTo(agentSignUpDto.businessCode)
+        assertThat(agent.companyName).isEqualTo(agentSignUpDto.companyName)
+        assertThat(agent.agentName).isEqualTo(agentSignUpDto.agentName)
+        assertThat(agent.companyPhoneNum).isEqualTo(agentSignUpDto.companyPhoneNum)
+        assertThat(agent.companyEmail).isEqualTo(agentSignUpDto.companyEmail)
+        assertThat(agent.estate).isEqualTo(Estate.APARTMENT)
+        assertThat(agent.companyAddress).isEqualTo(agentSignUpDto.companyAddress + " " + agentSignUpDto.companyAddressDetail)
+    }
 }

--- a/src/test/kotlin/com/example/jhouse_server/global/util/MockEntity.kt
+++ b/src/test/kotlin/com/example/jhouse_server/global/util/MockEntity.kt
@@ -23,6 +23,7 @@ import com.example.jhouse_server.domain.user.*
 import com.example.jhouse_server.domain.user.entity.Age
 import com.example.jhouse_server.domain.user.entity.Authority
 import com.example.jhouse_server.domain.user.entity.User
+import com.example.jhouse_server.domain.user.entity.UserType
 
 class MockEntity {
     companion object {
@@ -44,7 +45,8 @@ class MockEntity {
             nickName = "철수",
             phoneNum = "01098765432",
             authority = Authority.ADMIN,
-            age = Age.TWENTY
+            age = Age.TWENTY,
+            userType = UserType.NONE
         )
 
 
@@ -74,6 +76,25 @@ class MockEntity {
             phoneNum = "01033333333",
             age = "20대 미만",
             joinPaths = mutableListOf("네이버 카페", "인스타그램")
+        )
+
+        fun testAgentSignUpDto() = AgentSignUpReqDto(
+            email = "agent_jhouse_com",
+            password = "abcdefG123!",
+            nickName = "공인중개사",
+            phoneNum = "01044444444",
+            age = "20대 미만",
+            joinPaths = mutableListOf("네이버 카페", "인스타그램"),
+            agentCode = "123-456-789-01",
+            businessCode = "12345-6789",
+            companyName = "주말내집",
+            agentName = "오도리",
+            companyPhoneNum = "0212345678",
+            assistantName = null,
+            companyAddress = "서울특별시",
+            companyAddressDetail = "강남구",
+            companyEmail = "agent@duaily.net",
+            estate = "아파트"
         )
 
         fun testUserSignInDto() = UserSignInReqDto(


### PR DESCRIPTION
## 주요 작업 내용 
> 공인중개사 타입 회원가입 추가

## 작업 내용
- [x] UserType에 일반 사용자와 공인중개사 구분
- [x] User 클래스를 상속받아 Agent(공인중개사) 도메인 생성

## 변경점

- 액세스 토큰에 UserType을 구분하는 claim 추가

이유 : 공인중개사는 관리자가 승인을 해주어야 회원가입이 완료되므로 그 이전에는 인증이 필요한 서비스는 사용할 수 없습니다. 따라서 ArgumentResolver에서 UserType을 구하기 위해 추가했습니다.

## CheckList

- [x] CI를 통과했나요?
- [ ] 리뷰어를 등록했나요?
- [ ] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?