### PR TITLE
[Hotfix/board service] 말머리 선택값으로 사용할 수 있게 로직 변경

### DIFF
--- a/src/docs/asciidoc/board.adoc
+++ b/src/docs/asciidoc/board.adoc
@@ -1,5 +1,11 @@
 == Board API
 
+*게시글 작성 시, category 값은 Optional 입니다.*
+
+null로 보낼 경우, 서버 측에서 EMPTY 값으로 매핑 시키며 추후 수정 시, EMPTY 값으로 넣어주셔야 합니다.
+
+조회 시, category에 대한 필터링을 원한다면 유의미한 ENUM 값을 넣어주시면 됩니다. 없을 경우, 전체 조회로 간주합니다.
+
 ==== 1. 홍보 게시글 작성하기
 ===== Request
 include::{snippets}/ads-board-create/http-request.adoc[]
@@ -33,6 +39,10 @@ include::{snippets}/get-board-preview/http-response.adoc[]
 
 ==== prefix : 필수값
 ==== category, search, order(default : RECENT) : 선택값
+
+prefix 값은 게시판 타입입니다. 소개/자유/홍보
+
+category 값은 말머리 입니다. 없을 경우, 값을 보내지 않으면 말머리에 대한 필터링을 거치지 않고 데이터를 반환합니다.
 
 ===== Request
 include::{snippets}/get-board/http-request.adoc[]

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
@@ -16,8 +16,8 @@ data class BoardReqDto(
     val title: String? = null,
     @field:NotNull(message = "code는 필수값입니다.")
     val code: String? = null,
-    @field:NotNull(message = "말머리는 필수값입니다.")
-    val category: BoardCategory? = null,
+//    @field:NotNull(message = "말머리는 필수값입니다.")
+    val category: BoardCategory?,
     val imageUrls: List<String>,
     @field:NotNull(message = "게시글 타입은 필수값입니다.")
     val prefixCategory: PrefixCategory? = null,
@@ -29,8 +29,8 @@ data class BoardUpdateReqDto(
     val title: String? = null,
     @field:NotNull(message = "code는 필수값입니다.")
     val code: String? = null,
-    @field:NotNull(message = "말머리는 필수값입니다.")
-    val category: String? = null,
+//    @field:NotNull(message = "말머리는 필수값입니다.")
+    val category: String?,
     val imageUrls: List<String>,
     @field:NotNull(message = "게시글 타입은 필수값입니다.")
     val prefixCategory: String? = null,

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/dto/BoardReqDto.kt
@@ -24,32 +24,6 @@ data class BoardReqDto(
     val fixed: Boolean? = null, // 홍보 게시글에 대해서만 true 설정 가능
 )
 
-//data class BoardResDto(
-//        @JsonProperty
-//        val boardId: Long,
-//        @JsonProperty
-//        val title: String,
-//        @JsonProperty
-//        val code: String,
-//        @JsonProperty
-//        val oneLineContent: String,
-//        @JsonProperty
-//        val nickName: String,
-//        @JsonProperty
-//        val createdAt: Date?,
-//        @JsonProperty
-//        val imageUrl: String?,
-//        @JsonProperty
-//        val commentCount: Int,
-//        @JsonProperty
-//        val category: String,
-//        @JsonProperty
-//        val prefixCategory: String,
-//        @JsonProperty
-//        val fixed: Boolean
-//)
-
-
 data class BoardUpdateReqDto(
     @field:NotNull(message = "게시글 제목은 필수값입니다.")
     val title: String? = null,
@@ -102,8 +76,6 @@ fun toDto(board: Board) : BoardResOneDto {
     return BoardResOneDto(board.id, board.title, board.boardCode.code, board.user.nickName, Timestamp.valueOf(board.createdAt), board.imageUrls, board.love.size, board.category.name, board.prefixCategory.name, board.comment.size, board.comment.stream().map { com.example.jhouse_server.domain.comment.dto.toDto(it) }.toList())
 }
 fun sliceContentWithRegex(content : String) : String {
-//    val pattern = Regex("^[a-zA-Z가-힣].*[.!?]$")
-//    val validatedString = pattern.find(content)?.value ?: ""
     return if (content.length >= 200) {
         content.take(200)
     } else {

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/Board.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/Board.kt
@@ -60,7 +60,7 @@ class Board(
         this.boardCode = code
         this.content = content
         this.category = BoardCategory.values().firstOrNull { it.name == category }
-            ?: throw ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)
+            ?: BoardCategory.EMPTY
         this.imageUrls = imageUrls
         this.prefixCategory = PrefixCategory.values().firstOrNull { it.name == prefixCategory }
             ?: throw ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION)

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/BoardCategoryConverter.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/BoardCategoryConverter.kt
@@ -15,6 +15,8 @@ enum class BoardCategory(val value: String, val superCategory: PrefixCategory) {
 
     TREND("트렌드", PrefixCategory.INTRO),
     REVIEW("후기", PrefixCategory.INTRO),
+
+    EMPTY("태그 없음", PrefixCategory.ALL),
     ;
 }
 

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/BoardCategoryConverter.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/BoardCategoryConverter.kt
@@ -11,6 +11,7 @@ enum class BoardCategory(val value: String, val superCategory: PrefixCategory) {
 
     QUESTION("질문", PrefixCategory.DEFAULT),
     DAILY("일상", PrefixCategory.DEFAULT),
+    SHARING("나눔", PrefixCategory.DEFAULT),
 
     TREND("트렌드", PrefixCategory.INTRO),
     REVIEW("후기", PrefixCategory.INTRO),

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/entity/PrefixCategory.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/entity/PrefixCategory.kt
@@ -6,7 +6,8 @@ import javax.persistence.Converter
 enum class PrefixCategory(val value: String) {
     DEFAULT("자유"),
     INTRO("소개"),
-    ADVERTISEMENT("홍보");
+    ADVERTISEMENT("홍보"),
+    ALL("공통");
 
 }
 

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardRepositoryImpl.kt
@@ -13,7 +13,6 @@ import com.example.jhouse_server.domain.board.entity.QBoard.board
 import com.example.jhouse_server.domain.board.entity.QBoardCode.boardCode
 import com.example.jhouse_server.domain.comment.entity.QComment.comment
 import com.example.jhouse_server.domain.love.entity.QLove.love
-import com.example.jhouse_server.domain.user.entity.QUser
 import com.example.jhouse_server.domain.user.entity.QUser.user
 import com.example.jhouse_server.domain.user.entity.User
 import com.querydsl.core.types.OrderSpecifier
@@ -22,6 +21,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.support.PageableExecutionUtils
+import org.springframework.util.StringUtils.hasText
 
 class BoardRepositoryImpl(
         private var jpaQueryFactory: JPAQueryFactory
@@ -65,7 +65,7 @@ class BoardRepositoryImpl(
                 .selectFrom(board)
                 .join(board.boardCode, boardCode).fetchJoin()
                 .join(board.user, user).fetchJoin()
-                .where(board.useYn.eq(true), board.prefixCategory.eq(PrefixCategory.valueOf(boardListDto.prefix)),searchWithBoardCategory(boardListDto.category),searchWithKeyword(boardListDto.search))
+                .where(board.useYn.eq(true), filterWithPrefixCategory(boardListDto.prefix) ,searchWithBoardCategory(boardListDto.category),searchWithKeyword(boardListDto.search))
                 .orderBy(board.fixed.desc(), searchWithOrder(boardListDto.order))
                 .limit(pageable.pageSize.toLong())
                 .offset(pageable.offset)
@@ -75,6 +75,10 @@ class BoardRepositoryImpl(
                 .where(board.useYn.eq(true), board.prefixCategory.eq(PrefixCategory.valueOf(boardListDto.prefix)),searchWithBoardCategory(boardListDto.category),searchWithKeyword(boardListDto.search))
 
         return PageableExecutionUtils.getPage(result, pageable) {countQuery.fetch().size.toLong()}.map { toListDto(it) }
+    }
+
+    private fun filterWithPrefixCategory(prefix: String): BooleanExpression? {
+        return if(!hasText(prefix)) null else board.prefixCategory.eq(PrefixCategory.valueOf(prefix))
     }
 
 

--- a/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/service/BoardServiceImpl.kt
@@ -37,8 +37,9 @@ class BoardServiceImpl(
         val content = getContent(req.code!!)
         val fixed = if(req.prefixCategory == PrefixCategory.ADVERTISEMENT) req.fixed!! else false
         val code = boardCodeRepository.save(BoardCode(req.code))
+        val category = BoardCategory.values().firstOrNull { it == req.category } ?: BoardCategory.EMPTY
         val board = Board(
-            req.title!!, content, req.category!!, req.imageUrls, user, req.prefixCategory!!, fixed, code
+            req.title!!, content, category, req.imageUrls, user, req.prefixCategory!!, fixed, code
         )
         return boardRepository.save(board).id
     }


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

말머리 선택값으로 사용할 수 있게 로직 변경

## 작업 내용
- [ ] 말머리를 선택하지 않을 경우, EMPTY 값으로 매핑

## 변경점

- EMTPY 말머리 값 추가

이유 : 말머리를 선택적으로 사용할 수 있는 값으로 사용하기 위함

## CheckList

- [ ] CI를 통과했나요?
- [ ] 리뷰어를 등록했나요?
- [ ] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?