### PR TITLE
[hotfix] 댓글 생성/삭제 시, 게시글 캐싱 제거

### DIFF
--- a/src/main/kotlin/com/example/jhouse_server/domain/comment/service/CommentServiceImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/comment/service/CommentServiceImpl.kt
@@ -14,6 +14,7 @@ import com.example.jhouse_server.domain.user.entity.User
 import com.example.jhouse_server.global.exception.ApplicationException
 import com.example.jhouse_server.global.exception.ErrorCode
 import com.example.jhouse_server.global.util.findByIdOrThrow
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,6 +29,7 @@ class CommentServiceImpl(
         return boardRepository.findByIdOrThrow(postId).comment.map { toDto(it) }
     }
 
+    @CacheEvict(allEntries = true, cacheManager = "cacheManager", value = ["board"])
     @Transactional
     override fun createComment(req: CommentReqDto, user: User): Long {
         val board = boardRepository.findByIdOrThrow(req.boardId)
@@ -52,6 +54,7 @@ class CommentServiceImpl(
         } else throw ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION)
     }
 
+    @CacheEvict(allEntries = true, cacheManager = "cacheManager", value = ["board"])
     @Transactional
     override fun deleteComment(commentId: Long, user: User) {
         val comment = commentRepository.findByIdOrThrow(commentId)


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

댓글 생성/삭제 시, 게시글 캐싱 제거

## 작업 내용
- [ ] 댓글 테이블의 변경사항이 캐싱에 영향을 주고 있음을 발견해서 댓글에도 캐싱 제거 어노테이션 추가


## CheckList

- [ ] CI를 통과했나요?
- [ ] 리뷰어를 등록했나요?
- [ ] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?