### PR TITLE
[fix] 게시글 목록 조회 시, 중복 데이터 제거

### DIFF
--- a/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/board/repository/BoardRepositoryImpl.kt
@@ -67,6 +67,7 @@ class BoardRepositoryImpl(
                 .join(board.user, user).fetchJoin()
                 .leftJoin(board.comment, comment)
                 .where(board.useYn.eq(true), filterWithPrefixCategory(boardListDto.prefix) ,searchWithBoardCategory(boardListDto.category),searchWithKeyword(boardListDto.search))
+                .groupBy(board.id)
                 .orderBy(board.fixed.desc(), searchWithOrder(boardListDto.order))
                 .limit(pageable.pageSize.toLong())
                 .offset(pageable.offset)


### PR DESCRIPTION
## 주요 작업 내용 
> 한 줄로 정리해주세요.

게시글 목록 조회 시, 중복 데이터 제거

## 작업 내용
- [ ] 게시글 id 기준 group by 적용

## CheckList

- [ ] CI를 통과했나요?
- [ ] 리뷰어를 등록했나요?
- [ ] 참고 레퍼런스가 있을 경우, PR 혹은 댓글로 남겼나요?