### PR TITLE
[Hotfix/user service] 사용자 테이블 컬럼명 변경에 따른 AttributeConverter 와 Jpa 간 충돌

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -38,7 +38,6 @@ include::{snippets}/sign-up/http-request.adoc[]
 ===== Response - Success
 include::{snippets}/sign-up/http-response.adoc[]
 ===== Response - Fail
-include::{snippets}/email-validation/http-response.adoc[]
 include::{snippets}/password-validation/http-response.adoc[]
 include::{snippets}/nickname-validation/http-response.adoc[]
 include::{snippets}/phonenum-validation/http-response.adoc[]
@@ -59,7 +58,6 @@ include::{snippets}/sign-in/http-response.adoc[]
 ===== Response - Fail
 include::{snippets}/sign-in-exception-1/http-response.adoc[]
 include::{snippets}/sign-in-exception-2/http-response.adoc[]
-include::{snippets}/email-validation/http-response.adoc[]
 include::{snippets}/password-validation/http-response.adoc[]
 
 === 3. 토큰 재발급
@@ -76,11 +74,9 @@ include::{snippets}/logout/http-response.adoc[]
 
 === 5. 이메일 중복 검사
 ===== Request
-include::{snippets}/email-check/http-request.adoc[]
+include::{snippets}/check-email/http-request.adoc[]
 ===== Response - Success
-include::{snippets}/email-check/http-response.adoc[]
-===== Response - Fail
-include::{snippets}/email-validation/http-response.adoc[]
+include::{snippets}/check-email/http-response.adoc[]
 
 === 6. 닉네임 중복 검사
 ===== Request

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
@@ -18,11 +18,11 @@ import javax.persistence.*
 @Entity
 @DiscriminatorValue("U")
 class User(
-    @Convert(converter = CryptoConverter::class)
-    @Column(nullable = true)
+
+    @Column(name = "email", nullable = true)
     var email: String,
 
-    @Convert(converter = CryptoConverter::class)
+    @Column(name = "user_name")
     var userName: String,
 
     @Convert(converter = CryptoConverter::class)

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
@@ -19,7 +19,7 @@ import javax.persistence.*
 @DiscriminatorValue("U")
 class User(
 
-    @Column(name = "email", nullable = true)
+    @Column(name = "email제", nullable = true)
     var email: String,
 
     @Column(name = "user_name")

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/entity/User.kt
@@ -19,7 +19,7 @@ import javax.persistence.*
 @DiscriminatorValue("U")
 class User(
 
-    @Column(name = "email제", nullable = true)
+    @Column(name = "email", nullable = true)
     var email: String,
 
     @Column(name = "user_name")

--- a/src/main/kotlin/com/example/jhouse_server/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/jhouse_server/domain/user/repository/UserRepository.kt
@@ -16,15 +16,15 @@ interface UserRepository: JpaRepository<User, Long> , UserRepositoryCustom{
 
     fun countByWithdrawalStatusAndUserType(status: WithdrawalStatus, userType: UserType): Long
 
-    fun existsByUserName(userName: String): Boolean
+    fun existsByUserName(userName: String) : Boolean
 
     fun existsByNickName(nickName: String): Boolean
 
     fun existsByPhoneNum(phoneNum: String): Boolean
 
-    fun findByUserName(userName: String): Optional<User>
+    fun findByUserName(userName: String) : Optional<User>
 
-    fun findByUserNameAndSuspension(userName: String, suspension: Boolean): Optional<User>
+    fun findByUserNameAndSuspension(userName : String, suspension: Boolean) : Optional<User>
 
     fun findByUserNameAndAuthority(userName: String, authority: Authority) : Optional<User>
 

--- a/src/main/kotlin/com/example/jhouse_server/global/resolver/AuthUserResolver.kt
+++ b/src/main/kotlin/com/example/jhouse_server/global/resolver/AuthUserResolver.kt
@@ -38,8 +38,8 @@ class AuthUserResolver (
 
         tokenProvider.validateToken(jwt, true)
 
-        val email: String = tokenProvider.getSubject(jwt)
-        val user = userRepository.findByUserNameAndSuspension(email, false).orElseThrow()
+        val userName: String = tokenProvider.getSubject(jwt)
+        val user = userRepository.findByUserNameAndSuspension(userName, false).orElseThrow()
 
         if(tokenProvider.getType(jwt) == UserType.AGENT) {
             val agent = user as Agent

--- a/src/main/resources/static/docs/board.html
+++ b/src/main/resources/static/docs/board.html
@@ -460,7 +460,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.gemXFe8PGiAVmhXJVSS01-Wcy3HoCaLNncjyI_nOilCfXEbvELsah5Reun2JYjnvJcEuzYMf6jpZlgzE1jlKPA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dlPAuPTnR65d7vss_Ze9jLKqzU9zrxThKCdkvp3acpYZrdzHqkKVObnF663B57I0YRs1RAkT3rKG13NBJOEt9g
 Accept: application/json
 Content-Length: 316
 Host: localhost:8080
@@ -491,7 +491,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 2583
+  "data" : 2814
 }</code></pre>
 </div>
 </div>
@@ -504,7 +504,7 @@ Content-Length: 65
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.gemXFe8PGiAVmhXJVSS01-Wcy3HoCaLNncjyI_nOilCfXEbvELsah5Reun2JYjnvJcEuzYMf6jpZlgzE1jlKPA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dlPAuPTnR65d7vss_Ze9jLKqzU9zrxThKCdkvp3acpYZrdzHqkKVObnF663B57I0YRs1RAkT3rKG13NBJOEt9g
 Accept: application/json
 Content-Length: 312
 Host: localhost:8080
@@ -534,7 +534,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 2581
+  "data" : 2812
 }</code></pre>
 </div>
 </div>
@@ -548,7 +548,7 @@ Content-Length: 65
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.C75yTYtVpWfzOYJ_638V6PmwBH1TkSJbInxzeIyxJb8mt-SER6IcCNqDFhuAYJ8HF0yXS5d39dF5Eonw2sHgiw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4NzksImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.EmPGtT9YOHRf9NxBQocnOGjf_jDWfScL82uSzTzSSQ7ACbKSLGbEcsJwLgLyZm9v1AY4bMyYD1OIMmJuRX9odA
 Accept: application/json
 Content-Length: 317
 Host: localhost:8080
@@ -578,7 +578,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 2574
+  "data" : 2805
 }</code></pre>
 </div>
 </div>
@@ -623,12 +623,12 @@ Content-Length: 532
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : [ {
-    "boardId" : 2571,
+    "boardId" : 2802,
     "title" : "짱구는 못말려",
     "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
     "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
     "nickName" : "테스트유저1",
-    "createdAt" : "2023-09-23T14:06:40.449+00:00",
+    "createdAt" : "2023-09-25T14:11:19.474+00:00",
     "imageUrl" : "img001",
     "commentCount" : 1,
     "category" : "TREND",
@@ -682,12 +682,12 @@ Content-Length: 839
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "boardId" : 2575,
+      "boardId" : 2806,
       "title" : "짱구는 못말려",
       "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:40.801+00:00",
+      "createdAt" : "2023-09-25T14:11:19.863+00:00",
       "imageUrl" : "img001",
       "commentCount" : 1,
       "category" : "TREND",
@@ -719,7 +719,7 @@ Content-Length: 839
 <h5 id="_request_6">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/2576 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/2807 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -740,21 +740,21 @@ Content-Length: 650
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "boardId" : 2576,
+    "boardId" : 2807,
     "title" : "짱구는 못말려",
     "code" : "&lt;body&gt; &lt;div&gt; &lt;h2&gt;짱구는 못말려&lt;/h2&gt; &lt;/div&gt; &lt;div&gt; &lt;i&gt;철수&lt;/i&gt;야 나랑 놀자 &lt;/div&gt; &lt;/body&gt;",
     "nickName" : "테스트유저1",
-    "createdAt" : "2023-09-23T14:06:40.919+00:00",
+    "createdAt" : "2023-09-25T14:11:19.960+00:00",
     "imageUrls" : [ "img001" ],
     "loveCount" : 0,
     "category" : "TREND",
     "prefixCategory" : "INTRO",
     "commentCount" : 1,
     "comments" : [ {
-      "commentId" : 46297,
+      "commentId" : 51542,
       "nickName" : "테스트유저1",
       "content" : "댓글이란다.",
-      "createdAt" : "2023-09-23T14:06:40.928+00:00"
+      "createdAt" : "2023-09-25T14:11:19.964+00:00"
     } ]
   }
 }</code></pre>
@@ -768,9 +768,9 @@ Content-Length: 650
 <h5 id="_request_7">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/boards/2577 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/boards/2808 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.gemXFe8PGiAVmhXJVSS01-Wcy3HoCaLNncjyI_nOilCfXEbvELsah5Reun2JYjnvJcEuzYMf6jpZlgzE1jlKPA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dlPAuPTnR65d7vss_Ze9jLKqzU9zrxThKCdkvp3acpYZrdzHqkKVObnF663B57I0YRs1RAkT3rKG13NBJOEt9g
 Accept: application/json
 Content-Length: 255
 Host: localhost:8080
@@ -800,7 +800,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 2577
+  "data" : 2808
 }</code></pre>
 </div>
 </div>
@@ -812,8 +812,8 @@ Content-Length: 65
 <h5 id="_request_8">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/boards/2572 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.C75yTYtVpWfzOYJ_638V6PmwBH1TkSJbInxzeIyxJb8mt-SER6IcCNqDFhuAYJ8HF0yXS5d39dF5Eonw2sHgiw
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/boards/2803 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4NzksImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.EmPGtT9YOHRf9NxBQocnOGjf_jDWfScL82uSzTzSSQ7ACbKSLGbEcsJwLgLyZm9v1AY4bMyYD1OIMmJuRX9odA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -885,7 +885,7 @@ Content-Length: 221
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/my?page=0 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.C75yTYtVpWfzOYJ_638V6PmwBH1TkSJbInxzeIyxJb8mt-SER6IcCNqDFhuAYJ8HF0yXS5d39dF5Eonw2sHgiw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4NzksImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.EmPGtT9YOHRf9NxBQocnOGjf_jDWfScL82uSzTzSSQ7ACbKSLGbEcsJwLgLyZm9v1AY4bMyYD1OIMmJuRX9odA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -906,18 +906,18 @@ Content-Length: 919
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "boardId" : 2569,
+      "boardId" : 2800,
       "title" : "짱구는 못말려",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
-      "createdAt" : "2023-09-23T14:06:40.198+00:00",
+      "createdAt" : "2023-09-25T14:11:18.841+00:00",
       "imageUrl" : "img001",
       "category" : "TREND",
       "prefixCategory" : "INTRO"
     }, {
-      "boardId" : 2570,
+      "boardId" : 2801,
       "title" : "짱구는 못말려",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
-      "createdAt" : "2023-09-23T14:06:40.224+00:00",
+      "createdAt" : "2023-09-25T14:11:19.140+00:00",
       "imageUrl" : "img001",
       "category" : "TREND",
       "prefixCategory" : "INTRO"
@@ -948,7 +948,7 @@ Content-Length: 919
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/my/comment?page=0 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.gemXFe8PGiAVmhXJVSS01-Wcy3HoCaLNncjyI_nOilCfXEbvELsah5Reun2JYjnvJcEuzYMf6jpZlgzE1jlKPA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dlPAuPTnR65d7vss_Ze9jLKqzU9zrxThKCdkvp3acpYZrdzHqkKVObnF663B57I0YRs1RAkT3rKG13NBJOEt9g
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -969,18 +969,18 @@ Content-Length: 919
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "boardId" : 2584,
+      "boardId" : 2815,
       "title" : "짱구는 못말려",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
-      "createdAt" : "2023-09-23T14:06:41.407+00:00",
+      "createdAt" : "2023-09-25T14:11:20.416+00:00",
       "imageUrl" : "img001",
       "category" : "TREND",
       "prefixCategory" : "INTRO"
     }, {
-      "boardId" : 2585,
+      "boardId" : 2816,
       "title" : "짱구는 못말려",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
-      "createdAt" : "2023-09-23T14:06:41.423+00:00",
+      "createdAt" : "2023-09-25T14:11:20.436+00:00",
       "imageUrl" : "img001",
       "category" : "TREND",
       "prefixCategory" : "INTRO"
@@ -1011,7 +1011,7 @@ Content-Length: 919
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/boards/my/love?page=0 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.gemXFe8PGiAVmhXJVSS01-Wcy3HoCaLNncjyI_nOilCfXEbvELsah5Reun2JYjnvJcEuzYMf6jpZlgzE1jlKPA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODAsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dlPAuPTnR65d7vss_Ze9jLKqzU9zrxThKCdkvp3acpYZrdzHqkKVObnF663B57I0YRs1RAkT3rKG13NBJOEt9g
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1032,18 +1032,18 @@ Content-Length: 919
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "boardId" : 2578,
+      "boardId" : 2809,
       "title" : "짱구는 못말려",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
-      "createdAt" : "2023-09-23T14:06:41.101+00:00",
+      "createdAt" : "2023-09-25T14:11:20.132+00:00",
       "imageUrl" : "img001",
       "category" : "TREND",
       "prefixCategory" : "INTRO"
     }, {
-      "boardId" : 2579,
+      "boardId" : 2810,
       "title" : "짱구는 못말려",
       "oneLineContent" : "짱구는 못말려철수야 나랑 놀자",
-      "createdAt" : "2023-09-23T14:06:41.121+00:00",
+      "createdAt" : "2023-09-25T14:11:20.151+00:00",
       "imageUrl" : "img001",
       "category" : "TREND",
       "prefixCategory" : "INTRO"

--- a/src/main/resources/static/docs/comment.html
+++ b/src/main/resources/static/docs/comment.html
@@ -449,7 +449,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h5 id="_request">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/comments/2624 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/comments/2855 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -470,10 +470,10 @@ Content-Length: 218
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : [ {
-    "commentId" : 46482,
+    "commentId" : 51727,
     "nickName" : "테스트유저1",
     "content" : "댓글이란다.",
-    "createdAt" : "2023-09-23T14:06:43.032+00:00"
+    "createdAt" : "2023-09-25T14:11:22.027+00:00"
   } ]
 }</code></pre>
 </div>
@@ -488,13 +488,13 @@ Content-Length: 218
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.444GUemLTiW_L6kemAXKlhFS2YXysCqYjrJa551UTn6gAdNuHP0FoL78B5tTFGrLecwgvoVLWQhlQhH2gkbJaA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.hWkoc3P5wRz0IvPXKnp_0c_8UwG8kcB9HCcqulqsSYpVxcdSDHzF8ossnPEjwuQ2_JUkQqtLIkpYT3WIUe04zA
 Accept: application/json
 Content-Length: 65
 Host: localhost:8080
 
 {
-  "boardId" : 2626,
+  "boardId" : 2857,
   "content" : "짱구야, 공부 하자."
 }</code></pre>
 </div>
@@ -514,7 +514,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 46497
+  "data" : 51742
 }</code></pre>
 </div>
 </div>
@@ -526,15 +526,15 @@ Content-Length: 66
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/comments/46488 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/comments/51733 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.444GUemLTiW_L6kemAXKlhFS2YXysCqYjrJa551UTn6gAdNuHP0FoL78B5tTFGrLecwgvoVLWQhlQhH2gkbJaA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.hWkoc3P5wRz0IvPXKnp_0c_8UwG8kcB9HCcqulqsSYpVxcdSDHzF8ossnPEjwuQ2_JUkQqtLIkpYT3WIUe04zA
 Accept: application/json
 Content-Length: 65
 Host: localhost:8080
 
 {
-  "boardId" : 2625,
+  "boardId" : 2856,
   "content" : "짱구야, 공부 하자."
 }</code></pre>
 </div>
@@ -554,7 +554,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 46488
+  "data" : 51733
 }</code></pre>
 </div>
 </div>
@@ -566,8 +566,8 @@ Content-Length: 66
 <h5 id="_request_4">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/comments/46503 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.444GUemLTiW_L6kemAXKlhFS2YXysCqYjrJa551UTn6gAdNuHP0FoL78B5tTFGrLecwgvoVLWQhlQhH2gkbJaA
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/comments/51748 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.hWkoc3P5wRz0IvPXKnp_0c_8UwG8kcB9HCcqulqsSYpVxcdSDHzF8ossnPEjwuQ2_JUkQqtLIkpYT3WIUe04zA
 Host: localhost:8080</code></pre>
 </div>
 </div>

--- a/src/main/resources/static/docs/house.html
+++ b/src/main/resources/static/docs/house.html
@@ -491,7 +491,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/houses HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.PxPbY5l9w4XGFaX2JRt8Y7yK021kJSGAD9ghbB5IToOIAyh2iOZQ49hRKb4Cgh3qCul-pAU32AEq7dZtYWFy7w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.P3SOAdkqMymRaOM8HYll6yRrJD3I_LuviVYqw4S-BuuH-P8_vi3qKbxU6SSaDeEg1BYQF_3OtobdWBVL_ga-yg
 Accept: application/json
 Content-Length: 660
 Host: localhost:8080
@@ -630,7 +630,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6333
+  "data" : 6888
 }</code></pre>
 </div>
 </div>
@@ -681,7 +681,7 @@ Content-Length: 65
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/houses HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDUsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dJ1FTzNKnVL25sr8qlPBj1AD7FgtOg0hrzu_9_Nze3okzJpJGT5mi5HPbnNthE7jU0p2Oz6O4URm_dkfJeZV0A
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.8SBySSBjT0U0oCkyB0a7avaBlsgG0tOo_hBkDr7cmgspqiTf2Z1NxVVbiPXfnfN8Ca0V102JN81X33nkAT7XSg
 Accept: application/json
 Content-Length: 26025
 Host: localhost:8080
@@ -834,9 +834,9 @@ Content-Length: 100
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/6310 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/6865 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.PxPbY5l9w4XGFaX2JRt8Y7yK021kJSGAD9ghbB5IToOIAyh2iOZQ49hRKb4Cgh3qCul-pAU32AEq7dZtYWFy7w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.P3SOAdkqMymRaOM8HYll6yRrJD3I_LuviVYqw4S-BuuH-P8_vi3qKbxU6SSaDeEg1BYQF_3OtobdWBVL_ga-yg
 Accept: application/json
 Content-Length: 683
 Host: localhost:8080
@@ -975,7 +975,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6310
+  "data" : 6865
 }</code></pre>
 </div>
 </div>
@@ -990,9 +990,9 @@ Content-Length: 65
 <h5 id="_request_4">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/houses/6309 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/houses/6864 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.PxPbY5l9w4XGFaX2JRt8Y7yK021kJSGAD9ghbB5IToOIAyh2iOZQ49hRKb4Cgh3qCul-pAU32AEq7dZtYWFy7w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.P3SOAdkqMymRaOM8HYll6yRrJD3I_LuviVYqw4S-BuuH-P8_vi3qKbxU6SSaDeEg1BYQF_3OtobdWBVL_ga-yg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1108,104 +1108,104 @@ Content-Length: 4228
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "houseId" : 6377,
+      "houseId" : 6912,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.713+00:00",
+      "createdAt" : "2023-09-25T14:11:24.589+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6359,
+      "houseId" : 6914,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.686+00:00",
+      "createdAt" : "2023-09-25T14:11:24.592+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6361,
+      "houseId" : 6916,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.689+00:00",
+      "createdAt" : "2023-09-25T14:11:24.595+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6363,
+      "houseId" : 6932,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.691+00:00",
+      "createdAt" : "2023-09-25T14:11:24.615+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6365,
+      "houseId" : 6930,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.693+00:00",
+      "createdAt" : "2023-09-25T14:11:24.613+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6367,
+      "houseId" : 6922,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.695+00:00",
+      "createdAt" : "2023-09-25T14:11:24.603+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6369,
+      "houseId" : 6924,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.698+00:00",
+      "createdAt" : "2023-09-25T14:11:24.605+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6371,
+      "houseId" : 6926,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.703+00:00",
+      "createdAt" : "2023-09-25T14:11:24.608+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
@@ -1374,7 +1374,7 @@ Content-Length: 4228
 <h6 id="_request_6">Request</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/6379 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/6934 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -1396,7 +1396,7 @@ Content-Length: 953
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "houseId" : 6379,
+    "houseId" : 6934,
     "rentalType" : "SALE",
     "city" : "서울시 서대문구 남가좌동 거북골로 34",
     "zipcode" : "12345",
@@ -1413,7 +1413,7 @@ Content-Length: 953
     "imageUrls" : [ "img-001", "img-002" ],
     "nickName" : "테스트유저1",
     "userType" : "NONE",
-    "createdAt" : "2023-09-23T14:06:45.915+00:00",
+    "createdAt" : "2023-09-25T14:11:24.796+00:00",
     "isCompleted" : false,
     "isScraped" : false,
     "recommendedTag" : [ ],
@@ -1569,9 +1569,9 @@ Content-Length: 953
 <h6 id="_request_7">Request</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/user-scrap/6311 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/user-scrap/6866 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.PxPbY5l9w4XGFaX2JRt8Y7yK021kJSGAD9ghbB5IToOIAyh2iOZQ49hRKb4Cgh3qCul-pAU32AEq7dZtYWFy7w
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.P3SOAdkqMymRaOM8HYll6yRrJD3I_LuviVYqw4S-BuuH-P8_vi3qKbxU6SSaDeEg1BYQF_3OtobdWBVL_ga-yg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1592,7 +1592,7 @@ Content-Length: 952
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "houseId" : 6311,
+    "houseId" : 6866,
     "rentalType" : "SALE",
     "city" : "서울시 서대문구 남가좌동 거북골로 34",
     "zipcode" : "12345",
@@ -1609,7 +1609,7 @@ Content-Length: 952
     "imageUrls" : [ "img-001", "img-002" ],
     "nickName" : "테스트유저1",
     "userType" : "NONE",
-    "createdAt" : "2023-09-23T14:06:44.630+00:00",
+    "createdAt" : "2023-09-25T14:11:23.608+00:00",
     "isCompleted" : false,
     "isScraped" : true,
     "recommendedTag" : [ ],
@@ -1768,9 +1768,9 @@ Content-Length: 952
 <h6 id="_request_8">Request</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/report/6334 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/report/6889 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NDc5ODA0LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.7cvFqVeqrNGoC7CLr-RGizxv25yJ7RLnWr-h2t-CdPMFX7bqV6Baow5Zd0Yv3h-hUH5JkQNs3XJ5Ld2NTmQsMA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NjUyODgzLCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.frQUQt3diwt_HK66kq8KJWumNR22iGXmdMZoF3x7QXBVQmQSI8Mbwzvp8qFsbNWd7z2jMUGfsi2rzFATgWUtDg
 Accept: application/json
 Content-Length: 107
 Host: localhost:8080
@@ -1841,7 +1841,7 @@ Content-Length: 48
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/tmp-save?page=0&amp;size=8 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDUsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.dJ1FTzNKnVL25sr8qlPBj1AD7FgtOg0hrzu_9_Nze3okzJpJGT5mi5HPbnNthE7jU0p2Oz6O4URm_dkfJeZV0A
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.8SBySSBjT0U0oCkyB0a7avaBlsgG0tOo_hBkDr7cmgspqiTf2Z1NxVVbiPXfnfN8Ca0V102JN81X33nkAT7XSg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1863,104 +1863,104 @@ Content-Length: 4468
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "houseId" : 6346,
+      "houseId" : 6901,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.318+00:00",
+      "createdAt" : "2023-09-25T14:11:24.249+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6347,
+      "houseId" : 6902,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.319+00:00",
+      "createdAt" : "2023-09-25T14:11:24.251+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6348,
+      "houseId" : 6903,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.322+00:00",
+      "createdAt" : "2023-09-25T14:11:24.252+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6349,
+      "houseId" : 6904,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.323+00:00",
+      "createdAt" : "2023-09-25T14:11:24.253+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6350,
+      "houseId" : 6905,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.324+00:00",
+      "createdAt" : "2023-09-25T14:11:24.254+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6351,
+      "houseId" : 6906,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.326+00:00",
+      "createdAt" : "2023-09-25T14:11:24.258+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6352,
+      "houseId" : 6907,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.327+00:00",
+      "createdAt" : "2023-09-25T14:11:24.259+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6353,
+      "houseId" : 6908,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:45.328+00:00",
+      "createdAt" : "2023-09-25T14:11:24.260+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
@@ -2179,7 +2179,7 @@ Content-Length: 4468
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/scrap?page=0 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.444GUemLTiW_L6kemAXKlhFS2YXysCqYjrJa551UTn6gAdNuHP0FoL78B5tTFGrLecwgvoVLWQhlQhH2gkbJaA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.hWkoc3P5wRz0IvPXKnp_0c_8UwG8kcB9HCcqulqsSYpVxcdSDHzF8ossnPEjwuQ2_JUkQqtLIkpYT3WIUe04zA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2200,78 +2200,78 @@ Content-Length: 3498
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "houseId" : 6297,
+      "houseId" : 6852,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:43.839+00:00",
+      "createdAt" : "2023-09-25T14:11:22.869+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6298,
+      "houseId" : 6853,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:43.856+00:00",
+      "createdAt" : "2023-09-25T14:11:22.890+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6299,
+      "houseId" : 6854,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:43.863+00:00",
+      "createdAt" : "2023-09-25T14:11:22.896+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6300,
+      "houseId" : 6855,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:43.867+00:00",
+      "createdAt" : "2023-09-25T14:11:22.900+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6301,
+      "houseId" : 6856,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:43.875+00:00",
+      "createdAt" : "2023-09-25T14:11:22.904+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6302,
+      "houseId" : 6857,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "테스트유저1",
-      "createdAt" : "2023-09-23T14:06:43.880+00:00",
+      "createdAt" : "2023-09-25T14:11:22.908+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
@@ -2316,7 +2316,7 @@ Content-Length: 3498
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/houses/agent?page=0&amp;search=&amp;isCompleted= HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZ2VudF9qaG91c2VfY29tIiwiZXhwIjoxNjk1NDc5ODA1LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJBR0VOVCJ9.BC-QjXHwnm9qIQm-QLqpwzn946QvGZYznzjD982ZTU2ApCJZk5whqZW-oBmfbUrgA_06mVoF69fbbU3PwIUhfg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZ2VudF9qaG91c2VfY29tIiwiZXhwIjoxNjk1NjUyODg0LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJBR0VOVCJ9.UeP5T6QfFl3aGYVL4Vbbc2YTnpLPXD9mdGPzFt0ByOkMKJnfEKshcaje8iiDTDYwowT9LM7cZ3YrFXhXjYEYSQ
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2337,130 +2337,130 @@ Content-Length: 5441
   "message" : "성공",
   "data" : {
     "content" : [ {
-      "houseId" : 6335,
+      "houseId" : 6890,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.145+00:00",
+      "createdAt" : "2023-09-25T14:11:24.085+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6336,
+      "houseId" : 6891,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.147+00:00",
+      "createdAt" : "2023-09-25T14:11:24.086+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6337,
+      "houseId" : 6892,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.148+00:00",
+      "createdAt" : "2023-09-25T14:11:24.087+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6338,
+      "houseId" : 6893,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.149+00:00",
+      "createdAt" : "2023-09-25T14:11:24.089+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6339,
+      "houseId" : 6894,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.150+00:00",
+      "createdAt" : "2023-09-25T14:11:24.090+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6340,
+      "houseId" : 6895,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.152+00:00",
+      "createdAt" : "2023-09-25T14:11:24.091+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6341,
+      "houseId" : 6896,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.153+00:00",
+      "createdAt" : "2023-09-25T14:11:24.092+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6342,
+      "houseId" : 6897,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.155+00:00",
+      "createdAt" : "2023-09-25T14:11:24.093+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6343,
+      "houseId" : 6898,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.156+00:00",
+      "createdAt" : "2023-09-25T14:11:24.094+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
       "recommendedTag" : [ ],
       "recommendedTagName" : [ ]
     }, {
-      "houseId" : 6344,
+      "houseId" : 6899,
       "rentalType" : "SALE",
       "city" : "서울시 서대문구 남가좌동 거북골로 34",
       "price" : 12000,
       "monthlyPrice" : 0.0,
       "nickName" : "공인중개사1",
-      "createdAt" : "2023-09-23T14:06:45.157+00:00",
+      "createdAt" : "2023-09-25T14:11:24.095+00:00",
       "isCompleted" : false,
       "imageUrl" : "img-001",
       "title" : "행복부동산에서 제공하는 서울시 빈집 매물입니다.",
@@ -2510,9 +2510,9 @@ Content-Length: 5441
 <h6 id="_request_12">Request</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/status/6308 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/houses/status/6863 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.444GUemLTiW_L6kemAXKlhFS2YXysCqYjrJa551UTn6gAdNuHP0FoL78B5tTFGrLecwgvoVLWQhlQhH2gkbJaA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.P3SOAdkqMymRaOM8HYll6yRrJD3I_LuviVYqw4S-BuuH-P8_vi3qKbxU6SSaDeEg1BYQF_3OtobdWBVL_ga-yg
 Accept: application/json
 Content-Length: 158
 Host: localhost:8080

--- a/src/main/resources/static/docs/love.html
+++ b/src/main/resources/static/docs/love.html
@@ -449,8 +449,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h5 id="_request">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/loves/2633 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDgsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.9mDkbyh4hmk-WnLU31nwwqyW2B8lI9RUViOPymF3VuP5y8KtXK8EgO1KcynGRoqfZOcb_mxq02FzH15jblczQg
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/loves/2864 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODcsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.h15mPD_wOJ1rwDoVNW_a5JqW4jNC1BOZtEs6IgxD7VXyS-1n07rWQYI-t0Ck1z0nr7uHu5I0orunpZ2Gwz3PUg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -470,7 +470,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 2633
+  "data" : 2864
 }</code></pre>
 </div>
 </div>
@@ -482,8 +482,8 @@ Content-Length: 65
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/loves/2636 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDgsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.9mDkbyh4hmk-WnLU31nwwqyW2B8lI9RUViOPymF3VuP5y8KtXK8EgO1KcynGRoqfZOcb_mxq02FzH15jblczQg
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/loves/2867 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODcsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.h15mPD_wOJ1rwDoVNW_a5JqW4jNC1BOZtEs6IgxD7VXyS-1n07rWQYI-t0Ck1z0nr7uHu5I0orunpZ2Gwz3PUg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -514,8 +514,8 @@ Content-Length: 48
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/loves/2637 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDgsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.9mDkbyh4hmk-WnLU31nwwqyW2B8lI9RUViOPymF3VuP5y8KtXK8EgO1KcynGRoqfZOcb_mxq02FzH15jblczQg
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/loves/2868 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODcsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.h15mPD_wOJ1rwDoVNW_a5JqW4jNC1BOZtEs6IgxD7VXyS-1n07rWQYI-t0Ck1z0nr7uHu5I0orunpZ2Gwz3PUg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>

--- a/src/main/resources/static/docs/notification.html
+++ b/src/main/resources/static/docs/notification.html
@@ -456,7 +456,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/notifications?read=false&amp;id= HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDksImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.tem_aV31mh97AlD5rhFfowWNKXqSMa0OmqhYlh3YR1BSC7QkqIyex1rKsns6gTYXEXKg7STfnrYSDCqrZKNMuA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODgsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.Hu1rDNBI9sJDE4nShCu9ag8qpMrUi6QsuFV_RKCh9Nkvc6z_BE6UZqnlLAEuvBR6jvoqpr4n5cjgBAcz3T448w
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -501,48 +501,48 @@ Content-Length: 2045
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "nextId" : 47180,
+    "nextId" : 52425,
     "notifications" : {
       "content" : [ {
         "nick_name" : "테스트유저1",
-        "board_id" : 2643,
+        "board_id" : 2874,
         "board_title" : "짱구는 못말려",
         "status" : false,
         "comment" : "짱구야, 공부 하자.",
         "comment_user" : "테스트유저2",
-        "notification_id" : 47188
+        "notification_id" : 52433
       }, {
         "nick_name" : "테스트유저1",
-        "board_id" : 2643,
+        "board_id" : 2874,
         "board_title" : "짱구는 못말려",
         "status" : false,
         "comment" : "짱구야, 공부 하자.",
         "comment_user" : "테스트유저2",
-        "notification_id" : 47186
+        "notification_id" : 52431
       }, {
         "nick_name" : "테스트유저1",
-        "board_id" : 2643,
+        "board_id" : 2874,
         "board_title" : "짱구는 못말려",
         "status" : false,
         "comment" : "짱구야, 공부 하자.",
         "comment_user" : "테스트유저2",
-        "notification_id" : 47184
+        "notification_id" : 52429
       }, {
         "nick_name" : "테스트유저1",
-        "board_id" : 2643,
+        "board_id" : 2874,
         "board_title" : "짱구는 못말려",
         "status" : false,
         "comment" : "짱구야, 공부 하자.",
         "comment_user" : "테스트유저2",
-        "notification_id" : 47182
+        "notification_id" : 52427
       }, {
         "nick_name" : "테스트유저1",
-        "board_id" : 2643,
+        "board_id" : 2874,
         "board_title" : "짱구는 못말려",
         "status" : false,
         "comment" : "짱구야, 공부 하자.",
         "comment_user" : "테스트유저2",
-        "notification_id" : 47180
+        "notification_id" : 52425
       } ],
       "pageable" : {
         "sort" : {
@@ -731,8 +731,8 @@ Content-Length: 2045
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/notifications/47136 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MDksImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.tem_aV31mh97AlD5rhFfowWNKXqSMa0OmqhYlh3YR1BSC7QkqIyex1rKsns6gTYXEXKg7STfnrYSDCqrZKNMuA
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/notifications/52381 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODgsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.Hu1rDNBI9sJDE4nShCu9ag8qpMrUi6QsuFV_RKCh9Nkvc6z_BE6UZqnlLAEuvBR6jvoqpr4n5cjgBAcz3T448w
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -773,7 +773,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47136
+  "data" : 52381
 }</code></pre>
 </div>
 </div>

--- a/src/main/resources/static/docs/record.html
+++ b/src/main/resources/static/docs/record.html
@@ -470,7 +470,7 @@ tech - architecture</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTEsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.5flCGxWML1gN4vHTe1jaXLooAyJ6yQvg0GfMleYu0HY7l_HGqOSNhq445De-W5An-B7NkaPyWlYcsRF9t_aD1A
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTAsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.uh--MCZ8RkM8Fq584wheSE_yP5shDPfROM8INRbocGJBQwetz_Dc7YOPAyUTZjIZ6T7rrKRToBgNo7_dXkI5Mg
 Accept: application/json
 Content-Length: 189
 Host: localhost:8080
@@ -499,7 +499,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47476
+  "data" : 52721
 }</code></pre>
 </div>
 </div>
@@ -511,9 +511,9 @@ Content-Length: 66
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record/47312 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record/52557 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTAsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.pZ-MTKW9snhmJNfRNzkGIvo4poUtW3KOY3gceh_ULryuKhDmKQ05jIS9ckDBUsx7EdNPfH5a0sqYXhzI09vP_Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODksImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.c1JBuj-yEb_KWaN9hfwanmrHaq4Gw9PvumLieg2dkmJyy2gVHGW1tYhO1qcBy5WHgV_lJ7m9MygrFtA9Pvi4hA
 Accept: application/json
 Content-Length: 62
 Host: localhost:8080
@@ -539,7 +539,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47312
+  "data" : 52557
 }</code></pre>
 </div>
 </div>
@@ -551,9 +551,9 @@ Content-Length: 66
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record/47367 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record/52612 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTAsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.pZ-MTKW9snhmJNfRNzkGIvo4poUtW3KOY3gceh_ULryuKhDmKQ05jIS9ckDBUsx7EdNPfH5a0sqYXhzI09vP_Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODksImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.c1JBuj-yEb_KWaN9hfwanmrHaq4Gw9PvumLieg2dkmJyy2gVHGW1tYhO1qcBy5WHgV_lJ7m9MygrFtA9Pvi4hA
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -607,13 +607,13 @@ Content-Length: 328
   "message" : "성공",
   "data" : {
     "records" : [ {
-      "record_id" : 47408,
+      "record_id" : 52653,
       "title" : "코드 리뷰 문화 도입"
     }, {
-      "record_id" : 47411,
+      "record_id" : 52656,
       "title" : "DDOS 대응 회고"
     }, {
-      "record_id" : 47414,
+      "record_id" : 52659,
       "title" : "인증 인가 직접 구현하기"
     } ]
   }
@@ -682,18 +682,18 @@ Content-Length: 1288
   "data" : {
     "records" : {
       "content" : [ {
-        "record_id" : 47495,
+        "record_id" : 52740,
         "title" : "인증 인가 직접 구현하기",
         "content" : "스프링 시큐리티를 사용하지 않고, 인증 인가를 직접 구현했습니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       }, {
-        "record_id" : 47498,
+        "record_id" : 52743,
         "title" : "인증 인가 직접 구현하기",
         "content" : "스프링 시큐리티를 사용하지 않고, 인증 인가를 직접 구현했습니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       } ],
       "pageable" : {
@@ -744,7 +744,7 @@ Content-Length: 1288
 <h5 id="_request_6">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/47433?page=0 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/52678?page=0 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -766,7 +766,7 @@ Content-Length: 1510
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "record_id" : 47433,
+    "record_id" : 52678,
     "title" : "코드 리뷰 문화 도입",
     "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
     "hits" : 1,
@@ -774,26 +774,26 @@ Content-Length: 1510
     "type" : "odori",
     "category" : "culture",
     "nick_name" : "테스트유저2",
-    "create_at" : "09.23.2023",
+    "create_at" : "09.25.2023",
     "comments" : {
       "content" : [ {
-        "comment_id" : 47448,
+        "comment_id" : 52693,
         "level" : 1,
         "content" : "댓글입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "09.23.2023"
+        "create_at" : "09.25.2023"
       }, {
-        "comment_id" : 47450,
+        "comment_id" : 52695,
         "level" : 2,
         "content" : "댓글입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "09.23.2023"
+        "create_at" : "09.25.2023"
       }, {
-        "comment_id" : 47449,
+        "comment_id" : 52694,
         "level" : 1,
         "content" : "댓글입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "09.23.2023"
+        "create_at" : "09.25.2023"
       } ],
       "pageable" : {
         "sort" : {
@@ -840,9 +840,9 @@ reviewers : 리뷰 신청자 (approve - 승인, reject - 반려, wait - 대기)<
 <h5 id="_request_7">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/review/47380 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/review/52625 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTEsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.5flCGxWML1gN4vHTe1jaXLooAyJ6yQvg0GfMleYu0HY7l_HGqOSNhq445De-W5An-B7NkaPyWlYcsRF9t_aD1A
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODksImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.c1JBuj-yEb_KWaN9hfwanmrHaq4Gw9PvumLieg2dkmJyy2gVHGW1tYhO1qcBy5WHgV_lJ7m9MygrFtA9Pvi4hA
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -863,31 +863,31 @@ Content-Length: 982
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "record_id" : 47380,
+    "record_id" : 52625,
     "title" : "코드 리뷰 문화 도입",
     "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
     "hits" : 0,
     "part" : "server",
     "nick_name" : "테스트유저2",
-    "create_at" : "09.23.2023",
+    "create_at" : "09.25.2023",
     "reviews" : [ {
-      "review_id" : 47395,
+      "review_id" : 52640,
       "content" : "이 부분 수정해주세요.",
       "status" : "reject",
       "nick_name" : "테스트유저1",
-      "create_at" : "09.23.2023"
+      "create_at" : "09.25.2023"
     }, {
-      "review_id" : 47396,
+      "review_id" : 52641,
       "content" : "수정했습니다.",
       "status" : "mine",
       "nick_name" : "테스트유저2",
-      "create_at" : "09.23.2023"
+      "create_at" : "09.25.2023"
     }, {
-      "review_id" : 47397,
+      "review_id" : 52642,
       "content" : "확인했습니다!",
       "status" : "approve",
       "nick_name" : "테스트유저1",
-      "create_at" : "09.23.2023"
+      "create_at" : "09.25.2023"
     } ],
     "reviewers" : [ {
       "status" : "approve",
@@ -917,7 +917,7 @@ reject : 내가 작성한 글 중 반려 처리된 글</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/reviewee?status=wait&amp;page=0 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTAsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.pZ-MTKW9snhmJNfRNzkGIvo4poUtW3KOY3gceh_ULryuKhDmKQ05jIS9ckDBUsx7EdNPfH5a0sqYXhzI09vP_Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODksImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.c1JBuj-yEb_KWaN9hfwanmrHaq4Gw9PvumLieg2dkmJyy2gVHGW1tYhO1qcBy5WHgV_lJ7m9MygrFtA9Pvi4hA
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -940,25 +940,25 @@ Content-Length: 1454
   "data" : {
     "records" : {
       "content" : [ {
-        "record_id" : 47278,
+        "record_id" : 52523,
         "title" : "코드 리뷰 문화 도입",
         "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       }, {
-        "record_id" : 47281,
+        "record_id" : 52526,
         "title" : "DDOS 대응 회고",
         "content" : "DDOS 공격을 방지하기 위해 Bucket4j 라이브러리를 도입했습니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       }, {
-        "record_id" : 47284,
+        "record_id" : 52529,
         "title" : "이슈 제목",
         "content" : "이슈 내용입니다.",
         "nick_name" : "테스트유저1",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       } ],
       "pageable" : {
@@ -1011,7 +1011,7 @@ reject : 내가 반려 처리한 글</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record/reviewer?status=approve&amp;page=0 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTAsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.pZ-MTKW9snhmJNfRNzkGIvo4poUtW3KOY3gceh_ULryuKhDmKQ05jIS9ckDBUsx7EdNPfH5a0sqYXhzI09vP_Q
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4ODksImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.c1JBuj-yEb_KWaN9hfwanmrHaq4Gw9PvumLieg2dkmJyy2gVHGW1tYhO1qcBy5WHgV_lJ7m9MygrFtA9Pvi4hA
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1034,18 +1034,18 @@ Content-Length: 1228
   "data" : {
     "records" : {
       "content" : [ {
-        "record_id" : 47325,
+        "record_id" : 52570,
         "title" : "코드 리뷰 문화 도입",
         "content" : "pr 날린 코드에 대해 팀원들이 리뷰해줍니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       }, {
-        "record_id" : 47328,
+        "record_id" : 52573,
         "title" : "DDOS 대응 회고",
         "content" : "DDOS 공격을 방지하기 위해 Bucket4j 라이브러리를 도입했습니다.",
         "nick_name" : "테스트유저2",
-        "create_at" : "09.23.2023",
+        "create_at" : "09.25.2023",
         "part" : "server"
       } ],
       "pageable" : {

--- a/src/main/resources/static/docs/record_category.html
+++ b/src/main/resources/static/docs/record_category.html
@@ -463,7 +463,7 @@ architecture (기술 - 설계)</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record_category/template HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTIsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.OAhS2sZ9RZ0UdvF9HhLucbvCa9qkIFeCj25pzo5RcEb0QavSjqmrrSZVCFp-sVzlNQ00cPqpqFZxoi-TGzcDCg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTEsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.WVljAEmXjShLUa1RBnsYE0SCtwxNlJmHYwIJ_GiNCB94jKPHe5xX3_0MdoIc3LyWP_DYbS-TVfwJVAf9C0I_Aw
 Accept: application/json
 Content-Length: 67
 Host: localhost:8080
@@ -502,7 +502,7 @@ Content-Length: 48
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/record_category/template/culture HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTMsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.hKBsHC_zghipzSt0lZ_mDNjmbHfQfY33S5lUJOPSZa4sD4qYdAJHnJmC20D_bfOAU_bEHFZaCMvvX0XXGrEoYQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTEsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.WVljAEmXjShLUa1RBnsYE0SCtwxNlJmHYwIJ_GiNCB94jKPHe5xX3_0MdoIc3LyWP_DYbS-TVfwJVAf9C0I_Aw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>

--- a/src/main/resources/static/docs/record_comment.html
+++ b/src/main/resources/static/docs/record_comment.html
@@ -456,13 +456,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record_comment HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.ORUKcb9cOcjGnRiedccnEXQa5MT4jgQfQeXxGHG9oYv-rpa-WQDprcOF0PG6Fqzx3iRKuR-KXkBFsEmJojrfAw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.Ap0GCiQGNitfey9yfcxGcmMjvFXC8fmGtIjiNxfbtvLqK4KYBuI3U7LGDIxZU2vOwM077OZcE7q6pOCNlXCSMA
 Accept: application/json
 Content-Length: 81
 Host: localhost:8080
 
 {
-  "record_id" : 47651,
+  "record_id" : 52896,
   "parent_id" : null,
   "content" : "댓글입니다."
 }</code></pre>
@@ -483,7 +483,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47653
+  "data" : 52898
 }</code></pre>
 </div>
 </div>
@@ -495,9 +495,9 @@ Content-Length: 66
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_comment/47640 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_comment/52885 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.ORUKcb9cOcjGnRiedccnEXQa5MT4jgQfQeXxGHG9oYv-rpa-WQDprcOF0PG6Fqzx3iRKuR-KXkBFsEmJojrfAw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTIsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.Ap0GCiQGNitfey9yfcxGcmMjvFXC8fmGtIjiNxfbtvLqK4KYBuI3U7LGDIxZU2vOwM077OZcE7q6pOCNlXCSMA
 Accept: application/json
 Content-Length: 33
 Host: localhost:8080
@@ -522,7 +522,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47640
+  "data" : 52885
 }</code></pre>
 </div>
 </div>
@@ -534,9 +534,9 @@ Content-Length: 66
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_comment/47627 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_comment/52872 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTMsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.ORUKcb9cOcjGnRiedccnEXQa5MT4jgQfQeXxGHG9oYv-rpa-WQDprcOF0PG6Fqzx3iRKuR-KXkBFsEmJojrfAw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTEsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.D26AHw0n0arCetVglMVGscDf7KWNAnSEJBVLup9a3hukVzMB8fDQ8HvdwDT9n5iGaZa98AonrQtsdhr0A-AASw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>

--- a/src/main/resources/static/docs/record_review.html
+++ b/src/main/resources/static/docs/record_review.html
@@ -460,13 +460,13 @@ mine (레코드 작성자가 리뷰를 달 때)</pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/record_review HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTMsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.hKBsHC_zghipzSt0lZ_mDNjmbHfQfY33S5lUJOPSZa4sD4qYdAJHnJmC20D_bfOAU_bEHFZaCMvvX0XXGrEoYQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTIsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.sOHf_aQOSWrMfMB-0agwbGTvipc4DSUlOLgcbi_-Y3vQ85y_97rcqPy6HXoF6cDu_whDSv__jEL6C5GWnA_GWg
 Accept: application/json
 Content-Length: 94
 Host: localhost:8080
 
 {
-  "record_id" : 47697,
+  "record_id" : 52942,
   "content" : "좋은 글 감사합니다!",
   "status" : "approve"
 }</code></pre>
@@ -487,7 +487,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47700
+  "data" : 52945
 }</code></pre>
 </div>
 </div>
@@ -517,9 +517,9 @@ Content-Length: 76
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_review/47742 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/record_review/52987 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTQsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.tbLjyLbGuKGB_jKjXCU-6CaD0TiRzliQJggePOxRiCQDSBUSeELgkLLNpd4HxBSUXd_AVPP-d0ad7Q41FYJ7Ng
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTIsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.sOHf_aQOSWrMfMB-0agwbGTvipc4DSUlOLgcbi_-Y3vQ85y_97rcqPy6HXoF6cDu_whDSv__jEL6C5GWnA_GWg
 Accept: application/json
 Content-Length: 57
 Host: localhost:8080
@@ -545,7 +545,7 @@ Content-Length: 66
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 47742
+  "data" : 52987
 }</code></pre>
 </div>
 </div>
@@ -575,9 +575,9 @@ Content-Length: 76
 <h5 id="_request_3">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_review/47714 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/record_review/52959 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk4MTMsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.hKBsHC_zghipzSt0lZ_mDNjmbHfQfY33S5lUJOPSZa4sD4qYdAJHnJmC20D_bfOAU_bEHFZaCMvvX0XXGrEoYQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTIsImF1dGgiOiJBRE1JTiIsInR5cGUiOiJTRVJWRVIifQ.sOHf_aQOSWrMfMB-0agwbGTvipc4DSUlOLgcbi_-Y3vQ85y_97rcqPy6HXoF6cDu_whDSv__jEL6C5GWnA_GWg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>

--- a/src/main/resources/static/docs/scrap.html
+++ b/src/main/resources/static/docs/scrap.html
@@ -449,9 +449,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h5 id="_request">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/scraps/6481 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/scraps/7036 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NDc5ODE1LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.gbdz0PEEJkLOyUnUxPT6Q15K9D_pQTRTtyoG8jKp9g_wh5ueD1Blu_BLLlOiExiuFmaXLSH0QpXvtWUaxCDoFQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NjUyODk0LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.TgMb56w9mdGE4zXffV2qDefI33NDDQlUziUcc4j20VgXwpV2Q3IHrRp1Qt5Ui7nv8IpbmAJHk5mKRf3rnfm2kw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -471,7 +471,7 @@ Content-Length: 65
 {
   "code" : "SUCCESS",
   "message" : "성공",
-  "data" : 6481
+  "data" : 7036
 }</code></pre>
 </div>
 </div>
@@ -483,9 +483,9 @@ Content-Length: 65
 <h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/scraps/6479 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/scraps/7034 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NDc5ODE1LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.gbdz0PEEJkLOyUnUxPT6Q15K9D_pQTRTtyoG8jKp9g_wh5ueD1Blu_BLLlOiExiuFmaXLSH0QpXvtWUaxCDoFQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NjUyODkzLCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.8xrcaSZgbOW3qQxbBQjyGfsQMpqyr0gSniZD3elar8Pw-eJ0IyZI5-Ho1a26Q0PCCPut7XsXPy0Iu_kRGlC-5Q
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -516,9 +516,9 @@ Content-Length: 79
 <h6 id="_request_3">Request</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/scraps/6480 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/v1/scraps/7035 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NDc5ODE1LCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.gbdz0PEEJkLOyUnUxPT6Q15K9D_pQTRTtyoG8jKp9g_wh5ueD1Blu_BLLlOiExiuFmaXLSH0QpXvtWUaxCDoFQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Ml9qaG91c2VfY29tIiwiZXhwIjoxNjk1NjUyODkzLCJhdXRoIjoiVVNFUiIsInR5cGUiOiJOT05FIn0.8xrcaSZgbOW3qQxbBQjyGfsQMpqyr0gSniZD3elar8Pw-eJ0IyZI5-Ho1a26Q0PCCPut7XsXPy0Iu_kRGlC-5Q
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>

--- a/src/main/resources/static/docs/user.html
+++ b/src/main/resources/static/docs/user.html
@@ -547,21 +547,6 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 80
-
-{
-  "code" : "C0002",
-  "message" : "이메일 형식에 맞지 않습니다."
-}</code></pre>
-</div>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json;charset=UTF-8
 Content-Length: 83
 
 {
@@ -786,7 +771,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTYwODI3OTR9.ovRw--B9tuYTdnxzls0uF51Qo294cy7nAi73aVCSCb417n5FM--yjpP5MqBKEWFylT54ocC4GSH8-s-XN05SdQ; Path=/; Domain=localhost; Max-Age=604800; Expires=Sat, 30 Sep 2023 14:06:34 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTYyNTU4OTR9.bu4bYfrk3FaJmr9uc40GglTAd9sFvAKPjldun98_ymt9dZOTStqoJGGvFQguJMUG4aI4Q3qTWeRnSxoNVwxPJg; Path=/; Domain=localhost; Max-Age=604800; Expires=Mon, 2 Oct 2023 14:11:34 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 299
 
@@ -794,7 +779,7 @@ Content-Length: 299
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UcW1gKpJBsnKVQLIbgq6m86AjILlnfuEiUL6DmCF1pLQ9IQm3V_cZscJG2cHrOsP7ayTBdaBOW5oVFXO8iVKVQ"
+    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.MaVpqlBwHF8CGcQYgEqUy4cmPG7yR7CytX3wiEiqGkPfgMjxx_oUZosBY2iBYihX_UpZ7qHgsA6Nb0pVEWLzRw"
   }
 }</code></pre>
 </div>
@@ -839,21 +824,6 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 80
-
-{
-  "code" : "C0002",
-  "message" : "이메일 형식에 맞지 않습니다."
-}</code></pre>
-</div>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json;charset=UTF-8
 Content-Length: 83
 
 {
@@ -875,10 +845,10 @@ Content-Type: application/json;charset=UTF-8
 Accept: application/json
 Content-Length: 234
 Host: localhost:8080
-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UkPOQf0yV00wkumjkqYhV1OJQ6XWWm5_fdZKAAjNhBbAN1WHfnTJYsjhAAmvIqnbvtPtn9pKmlijtHKxqUgP8A
+Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.HqNzK_d5yPybBSDdcXyeqV42fpXjEVm3RWF9TeCAiS9gw_PeqeHx9BTqYzqUzlAU7snYc0lRsPxac3UB_QlB5Q
 
 {
-  "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UkPOQf0yV00wkumjkqYhV1OJQ6XWWm5_fdZKAAjNhBbAN1WHfnTJYsjhAAmvIqnbvtPtn9pKmlijtHKxqUgP8A"
+  "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.HqNzK_d5yPybBSDdcXyeqV42fpXjEVm3RWF9TeCAiS9gw_PeqeHx9BTqYzqUzlAU7snYc0lRsPxac3UB_QlB5Q"
 }</code></pre>
 </div>
 </div>
@@ -891,7 +861,7 @@ Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleH
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTYwODI3OTZ9.mWAtQUeMnjpDgVswjmeymgR7BW5kalhnJnQMu0gduN5k5xxFORQT-MxExeB-eb79mFx7FfzfXL-lZKpDxw_2Gg; Path=/; Domain=localhost; Max-Age=604800; Expires=Sat, 30 Sep 2023 14:06:36 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTYyNTU4OTZ9.2WgDONbzSF_mYh53iB2SCfQvgV7MrqzpCCJxNFfRKndkKJTRPqWcfDKqrrhLV7UFWN3AEUICPB1nCRToxed0dw; Path=/; Domain=localhost; Max-Age=604800; Expires=Mon, 2 Oct 2023 14:11:36 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 299
 
@@ -899,7 +869,7 @@ Content-Length: 299
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UkPOQf0yV00wkumjkqYhV1OJQ6XWWm5_fdZKAAjNhBbAN1WHfnTJYsjhAAmvIqnbvtPtn9pKmlijtHKxqUgP8A"
+    "access_token" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.HqNzK_d5yPybBSDdcXyeqV42fpXjEVm3RWF9TeCAiS9gw_PeqeHx9BTqYzqUzlAU7snYc0lRsPxac3UB_QlB5Q"
   }
 }</code></pre>
 </div>
@@ -913,7 +883,7 @@ Content-Length: 299
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/logout HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UcW1gKpJBsnKVQLIbgq6m86AjILlnfuEiUL6DmCF1pLQ9IQm3V_cZscJG2cHrOsP7ayTBdaBOW5oVFXO8iVKVQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.MaVpqlBwHF8CGcQYgEqUy4cmPG7yR7CytX3wiEiqGkPfgMjxx_oUZosBY2iBYihX_UpZ7qHgsA6Nb0pVEWLzRw
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -927,7 +897,7 @@ Host: localhost:8080</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTYwODI3OTR9.ovRw--B9tuYTdnxzls0uF51Qo294cy7nAi73aVCSCb417n5FM--yjpP5MqBKEWFylT54ocC4GSH8-s-XN05SdQ; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTYyNTU4OTR9.bu4bYfrk3FaJmr9uc40GglTAd9sFvAKPjldun98_ymt9dZOTStqoJGGvFQguJMUG4aI4Q3qTWeRnSxoNVwxPJg; Path=/; Domain=localhost; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json;charset=UTF-8
 Content-Length: 48
 
@@ -948,11 +918,12 @@ Content-Length: 48
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/check/email HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 33
+Content-Length: 54
 Host: localhost:8080
 
 {
-  "email" : "test_jhouse_com"
+  "email" : "zzangu@jhouse.com",
+  "code" : "6335"
 }</code></pre>
 </div>
 </div>
@@ -972,24 +943,6 @@ Content-Length: 65
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : true
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_response_fail_3">Response - Fail</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json;charset=UTF-8
-Content-Length: 80
-
-{
-  "code" : "C0002",
-  "message" : "이메일 형식에 맞지 않습니다."
 }</code></pre>
 </div>
 </div>
@@ -1033,7 +986,7 @@ Content-Length: 65
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fail_4">Response - Fail</h5>
+<h5 id="_response_fail_3">Response - Fail</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
@@ -1088,7 +1041,7 @@ Content-Length: 48
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fail_5">Response - Fail</h5>
+<h5 id="_response_fail_4">Response - Fail</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
@@ -1135,7 +1088,7 @@ Host: localhost:8080
 
 {
   "phone_num" : "01011111111",
-  "code" : "9615"
+  "code" : "0585"
 }</code></pre>
 </div>
 </div>
@@ -1160,7 +1113,7 @@ Content-Length: 65
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fail_6">Response - Fail</h5>
+<h5 id="_response_fail_5">Response - Fail</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
@@ -1201,7 +1154,7 @@ Content-Length: 83
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users/update/nick-name HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UkPOQf0yV00wkumjkqYhV1OJQ6XWWm5_fdZKAAjNhBbAN1WHfnTJYsjhAAmvIqnbvtPtn9pKmlijtHKxqUgP8A
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTUsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.1DSCffuCTZiuumer5as9hashT0fTCWyQzkk6_zu7JiUUX0EMtRH92N-37VwfbTz4GFzAXvN_7bppwigoxeaTjQ
 Accept: application/json
 Content-Length: 30
 Host: localhost:8080
@@ -1231,7 +1184,7 @@ Content-Length: 48
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fail_7">Response - Fail</h5>
+<h5 id="_response_fail_6">Response - Fail</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
@@ -1272,7 +1225,7 @@ Content-Length: 80
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users/update/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTgsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.HDM9m1xI6KNAH57OTfuwgJtbyR4MTbXF4FaMNbfW7z8PXheLJptYg4XhKgPcIb1Gv9_fYF3D0Gsh_E6WAOPDyg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTcsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.eq1kCAGQC34KgwYHBVprDZckFPlwm_4rwA5AN4sBA5slIEPWkGPtZI0kZZQU4bKx7NgHxjjEZwlDzi4jJD33jw
 Accept: application/json
 Content-Length: 32
 Host: localhost:8080
@@ -1302,7 +1255,7 @@ Content-Length: 48
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fail_8">Response - Fail</h5>
+<h5 id="_response_fail_7">Response - Fail</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
@@ -1390,7 +1343,7 @@ Content-Length: 83
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/v1/users HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTYsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UkPOQf0yV00wkumjkqYhV1OJQ6XWWm5_fdZKAAjNhBbAN1WHfnTJYsjhAAmvIqnbvtPtn9pKmlijtHKxqUgP8A
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTUsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.1DSCffuCTZiuumer5as9hashT0fTCWyQzkk6_zu7JiUUX0EMtRH92N-37VwfbTz4GFzAXvN_7bppwigoxeaTjQ
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -1411,7 +1364,7 @@ Content-Length: 405
   "code" : "SUCCESS",
   "message" : "성공",
   "data" : {
-    "id" : 46185,
+    "id" : 53168,
     "userName" : "test_jhouse_com",
     "nick_name" : "테스트유저1",
     "phone_num" : "01011111111",
@@ -1434,7 +1387,7 @@ Content-Length: 405
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/users HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTUsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.RnFtVKgyQENC-yjgheGl3wLuNccZU3W6ylOJ3n3tGQ3sDMOn7OCLNRN3CrOSDy_wMforFTReMmDyIscSeJZ8dw
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.MaVpqlBwHF8CGcQYgEqUy4cmPG7yR7CytX3wiEiqGkPfgMjxx_oUZosBY2iBYihX_UpZ7qHgsA6Nb0pVEWLzRw
 Accept: application/json
 Content-Length: 127
 Host: localhost:8080
@@ -1475,7 +1428,7 @@ Content-Length: 48
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/withdrawal HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU0Nzk3OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.UcW1gKpJBsnKVQLIbgq6m86AjILlnfuEiUL6DmCF1pLQ9IQm3V_cZscJG2cHrOsP7ayTBdaBOW5oVFXO8iVKVQ
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0X2pob3VzZV9jb20iLCJleHAiOjE2OTU2NTI4OTQsImF1dGgiOiJVU0VSIiwidHlwZSI6Ik5PTkUifQ.MaVpqlBwHF8CGcQYgEqUy4cmPG7yR7CytX3wiEiqGkPfgMjxx_oUZosBY2iBYihX_UpZ7qHgsA6Nb0pVEWLzRw
 Accept: application/json
 Content-Length: 109
 Host: localhost:8080
@@ -1506,7 +1459,7 @@ Content-Length: 48
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fail_9">Response - Fail</h5>
+<h5 id="_response_fail_8">Response - Fail</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 400 Bad Request
@@ -1524,13 +1477,97 @@ Content-Length: 76
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_14_이메일_인증번호_전송">14. 이메일 인증번호 전송</h3>
+<div class="sect4">
+<h5 id="_request_15">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/send/email HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Content-Length: 35
+Host: localhost:8080
+
+{
+  "email" : "zzangu@jhouse.com"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_5">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 48
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공"
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>이메일 전송 실패 시, 500 에러코드로 반환됩니다.</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_15_이메일_인증번호_검증">15. 이메일 인증번호 검증</h3>
+<div class="sect4">
+<h5 id="_request_16">Request</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/users/check/email HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Content-Length: 54
+Host: localhost:8080
+
+{
+  "email" : "zzangu@jhouse.com",
+  "code" : "6335"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_6">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 65
+
+{
+  "code" : "SUCCESS",
+  "message" : "성공",
+  "data" : true
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>이메일 인증코드는 전화번호 인증과 동일하게 <strong>3분의 유효시간</strong>을 설정해두었습니다. 해당 코드는 레디스에서 관리합니다.
+성
+인증 실패 시, 반환되는 데이터는 <strong>false</strong> 입니다.</p>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-23 22:25:27 +0900
+Last updated 2023-09-25 23:11:06 +0900
 </div>
 </div>
 </body>


### PR DESCRIPTION
## 이슈 정리

기존 User 테이블에 email ( 사용자 아이디 ) 로 사용하던 컬럼을 user_name으로 변경 후, email 값을 갖는 새로운 컬럼을 생성하였다.
DB 스키마에도 동일하게 반영하였다.

전 email 현 user_name 컬럼에는 AttributeConverter를 상속받은 CryptoConverter로 암복호화를 수행한다. 업데이트된 스키마와 Converter간의 컬럼 매핑 충돌로 데이터를 찾을 수 없다는 NPE 발생하는 오류가 생겼다.

이를 해결하고자 아래와 같이 수행했다.

1. @Column(name = "user_name") 어노테이션으로 명시적 컬럼명 지정

지정하였음에도 불구하고 converter에서 탐색하지 못함.

2. @Converter로 암호화된 데이터를 raw 값으로 복호화한 뒤, DB 테이블에 저장

순수 값을 갖는 데이터로 변경 후, 현 user_name 의 @Convert 어노테이션을 삭제하였음에도 NPE 발생

3. 현 user_name과 현 email 컬럼 모두에 @Convert 어노테이션 삭제

3번 방식으로 해당 이슈 해결하였다.
데이터가 캐싱된 것인지 이유는 알 수 없다. 모든 테스트를 하기 이전에 ./gradlew clean과 ./gradlew build를 하였음에도 오류는 동일했다.